### PR TITLE
Added missing setRenderer() and update() methods to Rickshaw.Graph.JSONP.js

### DIFF
--- a/src/js/Rickshaw.Graph.JSONP.js
+++ b/src/js/Rickshaw.Graph.JSONP.js
@@ -46,6 +46,15 @@ Rickshaw.Graph.JSONP = function(args) {
 
 			self.graph = new Rickshaw.Graph(args);
 			self.graph.render();
+			
+			self.setRenderer = function (x) {
+                        	self.graph.setRenderer(x);
+                       	}
+
+                      	self.update = function(x) {
+                       		self.graph.update(x)
+                       	}
+
 
 			if (typeof args.onComplete == 'function') {
 				args.onComplete(self);


### PR DESCRIPTION
I tried to change examples/extensions.html  to use Rickshaw.Graph.JSONP and it didn't work because it was missing setRenderer() and update() methods. I added wrapper methods to call the corresponding methods on graph. This seems to fix the problem.
 I'm just starting to learn javascript, so this might not be the best way to fix this problem.
