### PR TITLE
Fixed issue where x-axis ticks were 'undefined' or 'NaN' for certain series

### DIFF
--- a/src/js/Rickshaw.Fixtures.Time.js
+++ b/src/js/Rickshaw.Fixtures.Time.js
@@ -72,14 +72,12 @@ Rickshaw.Fixtures.Time = function() {
 		
 		if (unit.name == 'month') {
 			var nearFuture = new Date((time + unit.seconds - 1) * 1000);
-			var monthDate = [nearFuture.getUTCFullYear(), nearFuture.getUTCMonth() + 1, 1].join('-');
-			return new Date(monthDate).getTime() / 1000;
+			return new Date(nearFuture.getUTCFullYear(), nearFuture.getUTCMonth() + 1, 1, 0, 0, 0, 0).getTime() / 1000;
 		} 
 
 		if (unit.name == 'year') {
 			var nearFuture = new Date((time + unit.seconds - 1) * 1000);
-			var yearDate = [nearFuture.getUTCFullYear(), 1, 1].join('-');
-			return new Date(yearDate).getTime() / 1000;
+			return new Date(nearFuture.getUTCFullYear(), 1, 1, 0, 0, 0, 0).getTime() / 1000;
 		}
 
 		return Math.ceil(time / unit.seconds) * unit.seconds;


### PR DESCRIPTION
Was having trouble when x-axis ticks were scaled out to show month abbreviations.  Titles would show as `Undefined` or `NaN`.  Appeared to be a problem with the way the date string was being parsed in `Rickshaw.Fixtures.Time.ceil`.
