### PR TITLE
Check index boundaries.

### DIFF
--- a/rickshaw.js
+++ b/rickshaw.js
@@ -1478,7 +1478,7 @@ Rickshaw.Graph.HoverDetail = Rickshaw.Class.create({
 			.range([0, topSeriesData.length]);
 
 		var approximateIndex = Math.floor(domainIndexScale(domainX));
-		var dataIndex = approximateIndex || 0;
+		var dataIndex = Math.min(approximateIndex || 0, stackedData[0].length - 1);
 
 		for (var i = approximateIndex; i < stackedData[0].length - 1;) {
 


### PR DESCRIPTION
approximateIndex could round to outside the domain, so we need to do a Math.min against the length of the data.
