### PR TITLE
Add feature in Multiple type of chart use (in current, line and area)

### DIFF
--- a/examples/multiple.html
+++ b/examples/multiple.html
@@ -1,0 +1,100 @@
+<!doctype>
+<script src="../vendor/d3.min.js"></script>
+<script src="../vendor/d3.layout.min.js"></script>
+
+<!--<script src="../rickshaw.min.js"></script>-->
+<script src="../src/js/Rickshaw.js"></script>
+<script src="../src/js/Rickshaw.Class.js"></script>
+<script src="../src/js/Rickshaw.Graph.js"></script>
+<script src="../src/js/Rickshaw.Graph.Renderer.js"></script>
+<script src="../src/js/Rickshaw.Graph.Unstacker.js"></script>
+<script src="../src/js/Rickshaw.Graph.Renderer.Stack.js"></script>
+<script src="../src/js/Rickshaw.Graph.Renderer.Line.js"></script>
+<script src="../src/js/Rickshaw.Graph.Renderer.Bar.js"></script>
+<script src="../src/js/Rickshaw.Graph.Renderer.Area.js"></script>
+<script src="../src/js/Rickshaw.Graph.Renderer.Multi.js"></script>
+<script src="../src/js/Rickshaw.Graph.Renderer.ScatterPlot.js"></script>
+<script src="../src/js/Rickshaw.Series.js"></script>
+<script src="../src/js/Rickshaw.Series.FixedDuration.js"></script>
+
+<style>
+	.chart {float:left; border: 1px solid #333; margin: 5px;}
+</style>
+<div id="chart" class="chart"></div>
+<div id="chart2" class="chart"></div>
+<div id="chart3" class="chart"></div>
+
+<script>
+
+console.log('chart2');
+var graph2 = new Rickshaw.Graph( {
+	element: document.querySelector("#chart2")
+	, width: 300
+	, height: 200
+  , renderer: 'area'
+	, series: [
+		{
+			data: [ { x: 0, y: 40 }, { x: 1, y: 49 }, { x: 2, y: 38 }, { x: 3, y: 30 }, { x: 4, y: 32 } ]
+			, color: 'steelblue'
+		},
+		{
+			data: [ { x: 0, y: 60 }, { x: 1, y: 3 }, { x: 2, y: 14 }, { x: 3, y: 52 }, { x: 4, y: 21 } ]
+			, color: 'red'
+		},
+		{
+			data: [ { x: 0, y: 20 }, { x: 1, y: 15 }, { x: 2, y: 62 }, { x: 3, y: 42 }, { x: 4, y: 3 } ]
+      , color: 'green'
+		}
+	]
+} );
+graph2.render();
+
+console.log('chart3');
+var graph3 = new Rickshaw.Graph( {
+	element: document.querySelector("#chart3")
+	, width: 300
+	, height: 200
+  , renderer: 'line'
+	, series: [
+		{
+			data: [ { x: 0, y: 40 }, { x: 1, y: 49 }, { x: 2, y: 38 }, { x: 3, y: 30 }, { x: 4, y: 32 } ]
+			, color: 'steelblue'
+		},
+		{
+			data: [ { x: 0, y: 60 }, { x: 1, y: 3 }, { x: 2, y: 14 }, { x: 3, y: 52 }, { x: 4, y: 21 } ]
+			, color: 'red'
+		},
+		{
+			data: [ { x: 0, y: 20 }, { x: 1, y: 15 }, { x: 2, y: 62 }, { x: 3, y: 42 }, { x: 4, y: 3 } ]
+      , color: 'green'
+		}
+	]
+} );
+graph3.render();
+
+console.log('chart1');
+var graph = new Rickshaw.Graph( {
+	element: document.querySelector("#chart")
+	, width: 300
+	, height: 200
+  , renderer: 'multi'
+	, series: [
+		{
+			data: [ { x: 0, y: 40 }, { x: 1, y: 49 }, { x: 2, y: 38 }, { x: 3, y: 30 }, { x: 4, y: 32 } ]
+			, color: 'steelblue'
+      , renderer: 'area'
+		}
+		,{
+			data: [ { x: 0, y: 20 }, { x: 1, y: 15 }, { x: 2, y: 62 }, { x: 3, y: 42 }, { x: 4, y: 3 } ]
+      , color: 'green'
+		}
+    ,{
+			data: [ { x: 0, y: 60 }, { x: 1, y: 3 }, { x: 2, y: 14 }, { x: 3, y: 52 }, { x: 4, y: 21 } ]
+			, color: 'red'
+		}
+	]
+} );
+graph.render();
+
+</script>
+

--- a/src/js/Rickshaw.Graph.Renderer.Multi.js
+++ b/src/js/Rickshaw.Graph.Renderer.Multi.js
@@ -1,0 +1,56 @@
+Rickshaw.namespace('Rickshaw.Graph.Renderer.Multi');
+
+Rickshaw.Graph.Renderer.Multi = Rickshaw.Class.create( Rickshaw.Graph.Renderer, {
+
+	name: 'multi',
+
+	defaults: function($super) {
+
+		return Rickshaw.extend( $super(), {
+			unstack: true,
+			fill: false,
+			stroke: true
+		} );
+	},
+
+  render: function(){
+    var graph = this.graph;
+    var defaultRenderer = graph.defaultRenderer || 'line';
+    var seriesGroup = {};
+
+    seriesGroup[defaultRenderer] =
+      {series: [], element: null};
+
+    var rendererOrder = ['area', 'line'];
+
+    graph.series.forEach(function(series){
+      var rendererName = defaultRenderer;
+      if(series.hasOwnProperty('renderer')){
+        rendererName = series.renderer;
+      }
+      if(!seriesGroup.hasOwnProperty(rendererName)){
+        seriesGroup[rendererName] =
+          {series: [], element: null};
+      }
+      seriesGroup[rendererName].series.push(series);
+    });
+
+    rendererOrder.forEach(function(rendererName){
+      if(!seriesGroup.hasOwnProperty(rendererName))
+        return;
+
+      var series = seriesGroup[rendererName];
+      var renderer = graph._renderers[rendererName];
+      var element = d3.select('svg').append('svg:g').attr('class', rendererName);
+      series.element = element;
+      
+      graph.renderer = renderer;
+      graph.vis = series.element;
+      graph.series = series.series;
+		  graph.series.active = function() { return graph.series.filter( function(s) { return !s.disabled } ); };
+
+      graph.render();
+    });
+  }
+} );
+

--- a/src/js/Rickshaw.Graph.Renderer.js
+++ b/src/js/Rickshaw.Graph.Renderer.js
@@ -85,10 +85,14 @@ Rickshaw.Graph.Renderer = Rickshaw.Class.create( {
 		var fill = this.fill ? series.color : 'none';
 		var stroke = this.stroke ? series.color : 'none';
 
-		series.path.setAttribute('fill', fill);
-		series.path.setAttribute('stroke', stroke);
-		series.path.setAttribute('stroke-width', this.strokeWidth);
-		series.path.setAttribute('class', series.className);
+    if(series.path){
+		  series.path.setAttribute('fill', fill);
+		  series.path.setAttribute('stroke', stroke);
+		  series.path.setAttribute('stroke-width', this.strokeWidth);
+		  series.path.setAttribute('class', series.className);
+    }else{
+      throw "series.path is undefined";
+    }
 	},
 
 	configure: function(args) {

--- a/src/js/Rickshaw.Graph.js
+++ b/src/js/Rickshaw.Graph.js
@@ -41,7 +41,8 @@ Rickshaw.Graph = function(args) {
 			Rickshaw.Graph.Renderer.Line,
 			Rickshaw.Graph.Renderer.Bar,
 			Rickshaw.Graph.Renderer.Area,
-			Rickshaw.Graph.Renderer.ScatterPlot
+			Rickshaw.Graph.Renderer.ScatterPlot,
+			Rickshaw.Graph.Renderer.Multi
 		];
 
 		renderers.forEach( function(r) {


### PR DESCRIPTION
this patch enables us to use Mutile chart type, e.g. Area chart in background and Line chart in foreground.

TODO: enable all the chart type.

Show usage in example/multiple.html.
