### PR TITLE
Patch to  fix bug in Rickshaw.Fixtures.Time.ceil() time calculations for month and year time units

### DIFF
--- a/src/js/Rickshaw.Fixtures.Time.js
+++ b/src/js/Rickshaw.Fixtures.Time.js
@@ -72,12 +72,12 @@ Rickshaw.Fixtures.Time = function() {
 		
 		if (unit.name == 'month') {
 			var nearFuture = new Date((time + unit.seconds - 1) * 1000);
-			return new Date(nearFuture.getUTCFullYear(), nearFuture.getUTCMonth() + 1, 1, 0, 0, 0, 0).getTime() / 1000;
+			return new Date(nearFuture.getFullYear(), nearFuture.getMonth(), 1, 0, 0, 0, 0).getTime() / 1000;
 		} 
 
 		if (unit.name == 'year') {
 			var nearFuture = new Date((time + unit.seconds - 1) * 1000);
-			return new Date(nearFuture.getUTCFullYear(), 1, 1, 0, 0, 0, 0).getTime() / 1000;
+			return new Date(nearFuture.getFullYear(), 0, 1, 0, 0, 0, 0).getTime() / 1000;
 		}
 
 		return Math.ceil(time / unit.seconds) * unit.seconds;


### PR DESCRIPTION
Calculations should be done in local time because that is how a new Date(seconds) creates its time. Even if code uses UTC internally.
