### PR TITLE
Add ability for user to override circle radii in scatter-plot

### DIFF
--- a/src/js/Rickshaw.Graph.Renderer.ScatterPlot.js
+++ b/src/js/Rickshaw.Graph.Renderer.ScatterPlot.js
@@ -34,7 +34,7 @@ Rickshaw.Graph.Renderer.ScatterPlot = Rickshaw.Class.create( Rickshaw.Graph.Rend
 				.enter().append("svg:circle")
 				.attr("cx", function(d) { return graph.x(d.x) })
 				.attr("cy", function(d) { return graph.y(d.y) })
-				.attr("r", this.dotSize);
+				.attr("r", function(d) { return ("r" in d) ? d.r : graph.renderer.dotSize});
 
 			Array.prototype.forEach.call(nodes[0], function(n) {
 				n.setAttribute('fill', series.color);


### PR DESCRIPTION
Optional d.r in series can be used to allow user to override circle radii.
