### PR TITLE
fix bug in Rickshaw.Fixtures.Time.ceil(), for month and year units

### DIFF
--- a/src/js/Rickshaw.Fixtures.Time.js
+++ b/src/js/Rickshaw.Fixtures.Time.js
@@ -72,12 +72,28 @@ Rickshaw.Fixtures.Time = function() {
 		
 		if (unit.name == 'month') {
 			var nearFuture = new Date((time + unit.seconds - 1) * 1000);
-			return new Date(nearFuture.getUTCFullYear(), nearFuture.getUTCMonth() + 1, 1, 0, 0, 0, 0).getTime() / 1000;
+			var rounded = new Date(0);
+			rounded.setUTCFullYear(nearFuture.getUTCFullYear());
+			rounded.setUTCMonth(nearFuture.getUTCMonth());
+			rounded.setUTCDate(1);
+			rounded.setUTCHours(0);
+			rounded.setUTCMinutes(0);
+			rounded.setUTCSeconds(0);
+			rounded.setUTCMilliseconds(0);     			
+			return rounded.getTime() / 1000;
 		} 
 
 		if (unit.name == 'year') {
 			var nearFuture = new Date((time + unit.seconds - 1) * 1000);
-			return new Date(nearFuture.getUTCFullYear(), 1, 1, 0, 0, 0, 0).getTime() / 1000;
+			var rounded = new Date(0);
+			rounded.setUTCFullYear(nearFuture.getUTCFullYear());
+			rounded.setUTCMonth(0);
+			rounded.setUTCDate(1);
+			rounded.setUTCHours(0);
+			rounded.setUTCMinutes(0);
+			rounded.setUTCSeconds(0);
+			rounded.setUTCMilliseconds(0);     			
+			return rounded.getTime() / 1000;
 		}
 
 		return Math.ceil(time / unit.seconds) * unit.seconds;


### PR DESCRIPTION
The problem its fixing is that the second new Date() in ceil was being set in local time to the ceiling unit time and then getTime() was being called on it which meant the returned UTC microseconds are adjusted for the time zone when they shouldnt be.
