### PR TITLE
Set a proper default value for Rickshaw.Series.timeInterval and allow to set it via options.

### DIFF
--- a/src/js/Rickshaw.Series.js
+++ b/src/js/Rickshaw.Series.js
@@ -7,7 +7,11 @@ Rickshaw.Series = Rickshaw.Class.create( Array, {
 		options = options || {}
 
 		this.palette = new Rickshaw.Color.Palette(palette);
-
+		
+		this.setTimeInterval(typeof(options.timeInterval) === 'undefined' ?
+            		1 :
+            		options.timeInterval);
+            
 		this.timeBase = typeof(options.timeBase) === 'undefined' ? 
 			Math.floor(new Date().getTime() / 1000) : 
 			options.timeBase;


### PR DESCRIPTION
While playing with Rickshaw ive noticed that graph.series.addData only adds one data point and nothing more even if I call it a thousand times. This is because timeInterval is 0 per default so the calculation 

index \* this.timeInterval || 1 

always results in 1.
