### PR TITLE
Guard interpolateColor against non-Array objects and fix formatting

### DIFF
--- a/src/js/Rickshaw.Color.Palette.js
+++ b/src/js/Rickshaw.Color.Palette.js
@@ -11,38 +11,38 @@ Rickshaw.Color.Palette = function(args) {
 	this.runningIndex = 0;
 	this.generatorIndex = 0;
 
-  if (args.interpolatedStopCount) {
-    var schemeCount = this.scheme.length - 1;
-    var i, j, scheme = [];
-    for (i = 0; i < schemeCount; i++) {
-      scheme.push(this.scheme[i]);
-      var generator = d3.interpolateHsl(this.scheme[i], this.scheme[i + 1]);
-      for (j = 1; j < args.interpolatedStopCount; j++) {
-        scheme.push(generator((1 / args.interpolatedStopCount) * j));
-      }
-    }
-    scheme.push(this.scheme[this.scheme.length - 1]);
-    this.scheme = scheme;
-  }
-  this.rotateCount = this.scheme.length;
+	if (args.interpolatedStopCount) {
+		var schemeCount = this.scheme.length - 1;
+		var i, j, scheme = [];
+		for (i = 0; i < schemeCount; i++) {
+			scheme.push(this.scheme[i]);
+			var generator = d3.interpolateHsl(this.scheme[i], this.scheme[i + 1]);
+			for (j = 1; j < args.interpolatedStopCount; j++) {
+				scheme.push(generator((1 / args.interpolatedStopCount) * j));
+			}
+		}
+		scheme.push(this.scheme[this.scheme.length - 1]);
+		this.scheme = scheme;
+	}
+	this.rotateCount = this.scheme.length;
 
 	this.color = function(key) {
 		return this.scheme[key] || this.scheme[this.runningIndex++] || this.interpolateColor() || '#808080';
 	};
 
-  this.interpolateColor = function() {
-    if (!Array.isArray(this.scheme)) return;
-    var color;
-    if (this.generatorIndex == this.rotateCount * 2 - 1) {
-      color = d3.interpolateHsl(this.scheme[this.generatorIndex], this.scheme[0])(0.5);
-      this.generatorIndex = 0;
-      this.rotateCount *= 2;
-    } else {
-      color = d3.interpolateHsl(this.scheme[this.generatorIndex], this.scheme[this.generatorIndex + 1])(0.5);
-      this.generatorIndex++;
-    }
-    this.scheme.push(color);
-    return color;
-  };
+	this.interpolateColor = function() {
+		if (!Array.isArray(this.scheme)) return;
+		var color;
+		if (this.generatorIndex == this.rotateCount * 2 - 1) {
+			color = d3.interpolateHsl(this.scheme[this.generatorIndex], this.scheme[0])(0.5);
+			this.generatorIndex = 0;
+			this.rotateCount *= 2;
+		} else {
+			color = d3.interpolateHsl(this.scheme[this.generatorIndex], this.scheme[this.generatorIndex + 1])(0.5);
+			this.generatorIndex++;
+		}
+		this.scheme.push(color);
+		return color;
+	};
 
 };


### PR DESCRIPTION
This ensures that `this.scheme.push(color)` won't get called against a non-Array object.

The second commit changes 2-space tabs to `\t`.
