### PR TITLE
More graceful handling of ajax errors

### DIFF
--- a/src/js/Rickshaw.Graph.Ajax.js
+++ b/src/js/Rickshaw.Graph.Ajax.js
@@ -7,12 +7,13 @@ Rickshaw.Graph.Ajax = function(args) {
 
 	$.ajax( {
 		url: this.dataURL,
-		complete: function(response, status) {
-
-			if (status === 'error') {
-				console.log("error loading dataURL: " + this.dataURL);
+		error: function(response, status, errorThrown) {
+			console.log("error loading dataURL (" + args.dataURL + "): " + errorThrown);
+			if (typeof args.onError === 'function') {
+				args.onError(self);
 			}
-
+		},
+		success: function(data, status, response) {
 			var data = JSON.parse(response.responseText);	
 
 			if (typeof args.onData === 'function') {


### PR DESCRIPTION
Instead of continuing blindly on in the case of error, split out
success and error cases for ajax data requests and fire off
args.onError if it's a function for the error case.
