### PR TITLE
HoverDetail last second bar hovering for Bar-Renderer

### DIFF
--- a/src/js/Rickshaw.Graph.HoverDetail.js
+++ b/src/js/Rickshaw.Graph.HoverDetail.js
@@ -54,7 +54,7 @@ Rickshaw.Graph.HoverDetail = Rickshaw.Class.create({
 
 		var domainIndexScale = d3.scale.linear()
 			.domain([topSeriesData[0].x, topSeriesData.slice(-1).shift().x])
-			.range([0, topSeriesData.length  - 1]);
+			.range([0, graph.renderer.name == 'bar' ? topSeriesData.length - 1 : topSeriesData.length]);
 
 		var approximateIndex = Math.floor(domainIndexScale(domainX));
 		var dataIndex = Math.min(approximateIndex || 0, stackedData[0].length - 1);


### PR DESCRIPTION
When using the bar-renderer, the last second bar has a much smaller hit-area than the other bars. When there are many bars, hovering the last second bar is nearly impossible.

I created a workaround for this problem, but I don't know whether this is the correct way to fix this.
