### PR TITLE
Bug fix for visual error: added a resize step to the render function

### DIFF
--- a/src/js/Rickshaw.Graph.js
+++ b/src/js/Rickshaw.Graph.js
@@ -113,6 +113,12 @@ Rickshaw.Graph = function(args) {
 			.range([0, this.height]);
 	};
 
+	this.resizeSVG = function(){
+		d3.select(this.element.firstChild)
+			.attr("height",this.height)
+			.attr("width",this.width);
+	};
+
 	this.render = function() {
 
 		var stackedData = this.stackData();
@@ -123,6 +129,7 @@ Rickshaw.Graph = function(args) {
 		this.updateCallbacks.forEach( function(callback) {
 			callback();
 		} );
+		this.resizeSVG();
 	};
 
 	this.update = this.render;


### PR DESCRIPTION
The following code produces a visual error:

```
<div id="chart"></div>

<script>
  var data = [ { x: 0, y: 40 }, { x: 1, y: 49 }, { x: 2, y: 17 }, { x: 3, y: 42 } ];
  var graph = new Rickshaw.Graph( {
    element: document.querySelector("#chart"),
    width: 580,
    height: 250,
    series: [ {
      color: 'steelblue',
      data: data
    } ]
  } );
  var axes = new Rickshaw.Graph.Axis.Time( { graph: graph } );
  graph.render();

  // This is the additional code from the tutorial that causes the visual bug

  graph.width = 1000;
  graph.render();

  // everything scales well but because the svg element has not updated its size
  // it cuts off the rest of the graph.

</script>
```

My patch fixes this problem
