### PR TITLE
Add option to display legend in natural order

### DIFF
--- a/src/js/Rickshaw.Graph.Legend.js
+++ b/src/js/Rickshaw.Graph.Legend.js
@@ -14,7 +14,10 @@ Rickshaw.Graph.Legend = function(args) {
 
 	var series = graph.series
 		.map( function(s) { return s } )
-		.reverse();
+
+	if (!args.naturalOrder) {
+		series = series.reverse();
+	}
 
 	this.lines = [];
 


### PR DESCRIPTION
When rendering the legend as a row, it's more natural to lay the elements out if they're not reversed.  

I haven't modified the documentation, examples, as it's such a minor thing, but it seems like a common enough use case to be worth making the request.
