### PR TITLE
Add color schemes for OKAY, WARNING and CRITICAL

### DIFF
--- a/examples/colors.html
+++ b/examples/colors.html
@@ -4,8 +4,9 @@
 
 <script src="../vendor/d3.v2.js"></script>
 
-<script src="../rickshaw.min.js"></script>
 
+<script src="../rickshaw.min.js"></script>
+<script src="../src/js/Rickshaw.Fixtures.Color.js"></script>
 <style>
 section {
 	width: 300px;
@@ -35,7 +36,10 @@ var schemes = [
 	'cool',
 	'spectrum2000', 
 	'spectrum2001', 
-	'classic9'
+	'classic9',
+	'warning',
+	'okay',
+	'critical'
 ];
 
 schemes.forEach( function(name) {

--- a/src/js/Rickshaw.Fixtures.Color.js
+++ b/src/js/Rickshaw.Fixtures.Color.js
@@ -156,4 +156,31 @@ Rickshaw.Fixtures.Color = function() {
 		'#cc6699',
 		'#999900'
 	];
-};
+
+	this.schemes.okay = [
+		'#00AA00',
+		'#00FF00',
+		'#2AFF2A',
+		'#55FF55',
+		'#80FF80',
+		'#AAFFAA'
+	];
+
+	this.schemes.warning = [
+		'#D4AA00',
+		'#FFCC00',
+		'#FFD42A',
+		'#FFDD55',
+		'#FFE680',
+		'#FFEEAA'
+	];
+		
+	this.schemes.critical = [
+		'#AA0000',
+		'#FF0000',
+		'#FF2A2A',
+		'#FF5555',
+		'#FF8080',
+		'#FFAAAA'
+	];
+};	


### PR DESCRIPTION
Hi shutterstock,

I thought it'd be a cool addition to the normal color palettes in order to visualize things like the state of a runnin service.

It is similar to the colors used in minitoring systems like Nagios and Icinga to describe the state of certain monitored elements.

Hope you like it.

Thanks!

![nagios-color-palettes](https://f.cloud.github.com/assets/1198936/46429/350e4998-585d-11e2-919f-6f2bf9dd7c0d.png)
