### PR TITLE
This pull request mostly fixes #181

### DIFF
--- a/src/js/Rickshaw.Graph.Axis.Time.js
+++ b/src/js/Rickshaw.Graph.Axis.Time.js
@@ -1,5 +1,9 @@
 Rickshaw.namespace('Rickshaw.Graph.Axis.Time');
 
+function createDateAsUTC(date) {
+    return new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate(), date.getHours(), date.getMinutes(), date.getSeconds(), date.getMilliseconds()));
+    }
+
 Rickshaw.Graph.Axis.Time = function(args) {
 
 	var self = this;
@@ -71,7 +75,7 @@ Rickshaw.Graph.Axis.Time = function(args) {
 
 			var title = document.createElement('div');
 			title.classList.add('title');
-			title.innerHTML = o.unit.formatter(new Date(o.value * 1000));
+			title.innerHTML = o.unit.formatter(createDateAsUTC(new Date(o.value * 1000)));
 			element.appendChild(title);
 
 			self.graph.element.appendChild(element);

--- a/src/js/Rickshaw.Graph.Behavior.Series.Toggle.js
+++ b/src/js/Rickshaw.Graph.Behavior.Series.Toggle.js
@@ -4,8 +4,11 @@ Rickshaw.Graph.Behavior.Series.Toggle = function(args) {
 
 	this.graph = args.graph;
 	this.legend = args.legend;
-
+	this.sortable = args.sortable;
 	var self = this;
+	if (typeof this.sortable == 'undefined'){
+	    this.sortable = true;
+	}
 
 	this.addAnchor = function(line) {
 		var anchor = document.createElement('a');
@@ -71,7 +74,7 @@ Rickshaw.Graph.Behavior.Series.Toggle = function(args) {
 	};
 
 	if (this.legend) {
-
+	    if (this.sortable){
                 $(this.legend.list).sortable( {
                         start: function(event, ui) {
                                 ui.item.bind('no.onclick',
@@ -86,7 +89,7 @@ Rickshaw.Graph.Behavior.Series.Toggle = function(args) {
                                 }, 250);
                         }
                 })
-
+	    }
 		this.legend.lines.forEach( function(l) {
 			self.addAnchor(l);
 		} );

--- a/src/js/Rickshaw.Graph.RangeSlider.js
+++ b/src/js/Rickshaw.Graph.RangeSlider.js
@@ -8,26 +8,29 @@ Rickshaw.Graph.RangeSlider = function(args) {
 
     if (!controller) {
         var slider_create = function(element){
-            var slider = $(element).slider({
-
-                range : true,
-                min : graph.dataDomain()[0],
-                max : graph.dataDomain()[1],
-                values : [ graph.dataDomain()[0], graph.dataDomain()[1] ],
-                slide : function(event, ui) {
-
-                    graph.window.xMin = ui.values[0];
-                    graph.window.xMax = ui.values[1];
-                    graph.update();
-
-                    // if we're at an extreme, stick there
-                    if (graph.dataDomain()[0] == ui.values[0]) {
-                        graph.window.xMin = undefined;
+            var slider;
+            $( function() {
+                slider = $(element).slider({
+    
+                    range : true,
+                    min : graph.dataDomain()[0],
+                    max : graph.dataDomain()[1],
+                    values : [ graph.dataDomain()[0], graph.dataDomain()[1] ],
+                    slide : function(event, ui) {
+    
+                        graph.window.xMin = ui.values[0];
+                        graph.window.xMax = ui.values[1];
+                        graph.update();
+    
+                        // if we're at an extreme, stick there
+                        if (graph.dataDomain()[0] == ui.values[0]) {
+                            graph.window.xMin = undefined;
+                        }
+                        if (graph.dataDomain()[1] == ui.values[1]) {
+                            graph.window.xMax = undefined;
+                        }
                     }
-                    if (graph.dataDomain()[1] == ui.values[1]) {
-                        graph.window.xMax = undefined;
-                    }
-                }
+                });
             });
             this.slider = slider;
         }

--- a/src/js/Rickshaw.Graph.RangeSlider.js
+++ b/src/js/Rickshaw.Graph.RangeSlider.js
@@ -7,7 +7,7 @@ Rickshaw.Graph.RangeSlider = function(args) {
     var controller = this.controller = args.controller;
 
     if (!controller) {
-        var slider_create = function(element){
+        var sliderCreate = function(element){
             var slider;
             $( function() {
                 slider = $(element).slider({
@@ -34,7 +34,7 @@ Rickshaw.Graph.RangeSlider = function(args) {
             });
             this.slider = slider;
         }
-        var slider_update = function() {
+        var sliderUpdate = function() {
             var values = $(element).slider('option', 'values');
 
             $(element).slider('option', 'min', graph.dataDomain()[0]);
@@ -51,10 +51,10 @@ Rickshaw.Graph.RangeSlider = function(args) {
 
         }   
         
-        controller = { slider_create:slider_create, slider_update:slider_update};
+        controller = { sliderCreate:sliderCreate, sliderUpdate:sliderUpdate};
     }
-    controller.slider_create(element);
+    controller.sliderCreate(element);
 
     element.style.width = graph.width + 'px';
-    graph.onUpdate(function(){controller.slider_update()});
+    graph.onUpdate(function(){controller.sliderUpdate()});
 };

--- a/src/js/Rickshaw.Graph.RangeSlider.js
+++ b/src/js/Rickshaw.Graph.RangeSlider.js
@@ -2,54 +2,56 @@ Rickshaw.namespace('Rickshaw.Graph.RangeSlider');
 
 Rickshaw.Graph.RangeSlider = function(args) {
 
-	var element = this.element = args.element;
-	var graph = this.graph = args.graph;
+    var element = this.element = args.element;
+    var graph = this.graph = args.graph;
+    var controller = this.controller = args.controller;
 
-	$( function() {
-		$(element).slider( {
+    if (!controller) {
+        var slider_create = function(element){
+            var slider = $(element).slider({
 
-			range: true,
-			min: graph.dataDomain()[0],
-			max: graph.dataDomain()[1],
-			values: [ 
-				graph.dataDomain()[0],
-				graph.dataDomain()[1]
-			],
-			slide: function( event, ui ) {
+                range : true,
+                min : graph.dataDomain()[0],
+                max : graph.dataDomain()[1],
+                values : [ graph.dataDomain()[0], graph.dataDomain()[1] ],
+                slide : function(event, ui) {
 
-				graph.window.xMin = ui.values[0];
-				graph.window.xMax = ui.values[1];
-				graph.update();
+                    graph.window.xMin = ui.values[0];
+                    graph.window.xMax = ui.values[1];
+                    graph.update();
 
-				// if we're at an extreme, stick there
-				if (graph.dataDomain()[0] == ui.values[0]) {
-					graph.window.xMin = undefined;
-				}
-				if (graph.dataDomain()[1] == ui.values[1]) {
-					graph.window.xMax = undefined;
-				}
-			}
-		} );
-	} );
+                    // if we're at an extreme, stick there
+                    if (graph.dataDomain()[0] == ui.values[0]) {
+                        graph.window.xMin = undefined;
+                    }
+                    if (graph.dataDomain()[1] == ui.values[1]) {
+                        graph.window.xMax = undefined;
+                    }
+                }
+            });
+            this.slider = slider;
+        }
+        var slider_update = function() {
+            var values = $(element).slider('option', 'values');
 
-	element[0].style.width = graph.width + 'px';
+            $(element).slider('option', 'min', graph.dataDomain()[0]);
+            $(element).slider('option', 'max', graph.dataDomain()[1]);
 
-	graph.onUpdate( function() {
+            if (graph.window.xMin == undefined) {
+                values[0] = graph.dataDomain()[0];
+            }
+            if (graph.window.xMax == undefined) {
+                values[1] = graph.dataDomain()[1];
+            }
 
-		var values = $(element).slider('option', 'values');
+            $(element).slider('option', 'values', values);
 
-		$(element).slider('option', 'min', graph.dataDomain()[0]);
-		$(element).slider('option', 'max', graph.dataDomain()[1]);
+        }   
+        
+        controller = { slider_create:slider_create, slider_update:slider_update};
+    }
+    controller.slider_create(element);
 
-		if (graph.window.xMin == undefined) {
-			values[0] = graph.dataDomain()[0];
-		}
-		if (graph.window.xMax == undefined) {
-			values[1] = graph.dataDomain()[1];
-		}
-
-		$(element).slider('option', 'values', values);
-
-	} );
+    element.style.width = graph.width + 'px';
+    graph.onUpdate(function(){controller.slider_update()});
 };
-

--- a/src/js/Rickshaw.Graph.RangeSlider.js
+++ b/src/js/Rickshaw.Graph.RangeSlider.js
@@ -6,12 +6,12 @@ Rickshaw.Graph.RangeSlider = function(args) {
     var graph = this.graph = args.graph;
     var controller = this.controller = args.controller;
 
-    if (!controller) {
-        var sliderCreate = function(element){
-            var slider;
+    if (!controller) {        
+        controller = {sliderCreate:function(element, graph){
+            this.graph = graph;
+            var self = this;
             $( function() {
-                slider = $(element).slider({
-    
+                self.slider = $(element).slider({
                     range : true,
                     min : graph.dataDomain()[0],
                     max : graph.dataDomain()[1],
@@ -32,11 +32,9 @@ Rickshaw.Graph.RangeSlider = function(args) {
                     }
                 });
             });
-            this.slider = slider;
-        }
-        var sliderUpdate = function() {
+        },
+        sliderUpdate:function() {
             var values = $(element).slider('option', 'values');
-
             $(element).slider('option', 'min', graph.dataDomain()[0]);
             $(element).slider('option', 'max', graph.dataDomain()[1]);
 
@@ -49,11 +47,9 @@ Rickshaw.Graph.RangeSlider = function(args) {
 
             $(element).slider('option', 'values', values);
 
-        }   
-        
-        controller = { sliderCreate:sliderCreate, sliderUpdate:sliderUpdate};
+        }   };
     }
-    controller.sliderCreate(element);
+    controller.sliderCreate(element, graph);
 
     element.style.width = graph.width + 'px';
     graph.onUpdate(function(){controller.sliderUpdate()});

--- a/src/js/Rickshaw.Graph.Smoother.js
+++ b/src/js/Rickshaw.Graph.Smoother.js
@@ -4,24 +4,29 @@ Rickshaw.Graph.Smoother = function(args) {
 
 	this.graph = args.graph;
 	this.element = args.element;
-
+	this.controller = args.controller;
 	var self = this;
 
 	this.aggregationScale = 1;
-
-	if (this.element) {
-
-		$( function() {
-			$(self.element).slider( {
-				min: 1,
-				max: 100,
-				slide: function( event, ui ) {
-					self.setScale(ui.value);
-					self.graph.update();
-				}
-			} );
-		} );
+	if (!this.controller) {
+	    this.controller = {smootherCreate: function(element, graph, extension){
+	        this.graph = graph;
+	        this.extension = extension;
+	        if (element) {
+	            $( function() {
+	                $(element).slider( {
+	                    min: 1,
+	                    max: 100,
+	                    slide: function( event, ui ) {
+	                        self.setScale(ui.value);
+	                        self.graph.update();
+	                    }
+	                } );
+	            } );
+	        }
+	    }}
 	}
+	this.controller.smootherCreate(self.element, graph, self)
 
 	self.graph.stackData.hooks.data.push( {
 		name: 'smoother',

--- a/src/js/Rickshaw.Graph.Smoother.js
+++ b/src/js/Rickshaw.Graph.Smoother.js
@@ -26,7 +26,7 @@ Rickshaw.Graph.Smoother = function(args) {
 	        }
 	    }}
 	}
-	this.controller.smootherCreate(self.element, graph, self)
+	this.controller.smootherCreate(self.element, this.graph, self);
 
 	self.graph.stackData.hooks.data.push( {
 		name: 'smoother',

--- a/src/js/Rickshaw.Graph.js
+++ b/src/js/Rickshaw.Graph.js
@@ -208,7 +208,6 @@ Rickshaw.Graph = function(args) {
 		if (args.width || args.height) {
 			this.setSize(args);
 		}
-
 		Rickshaw.keys(this.defaults).forEach( function(k) {
 			this[k] = k in args ? args[k]
 				: k in this ? this[k]
@@ -216,6 +215,14 @@ Rickshaw.Graph = function(args) {
 		}, this );
 
 		this.setRenderer(args.renderer || this.renderer.name, args);
+		
+        if (args.series) {
+            this.series = args.series;
+            this.validateSeries(args.series);
+            this.series.active = function() { return self.series.filter( function(s) { return !s.disabled } ) };
+            this.discoverRange();
+        }
+		
 	};
 
 	this.setRenderer = function(name, args) {


### PR DESCRIPTION
RangeSlider and Smoother now accept optional wrapper that can be used to provide alternative solution to jquery/jqueryUI.

SeriesToggle now accepts sortable:false config var that will make the jquery DND codepath optional.

This brings rickshaw to be almost completly js framework agnostic and mostly fixes #181 bug report.

#181 will be 100% fixed after I come up with alternative DND solution - I think it might be a good idea to ship native HTML5 implementation of DND, and then fallback to jquery/wrapper around some other lib.

