### PR TITLE
Allow hover for next-to-last point in series

### DIFF
--- a/src/js/Rickshaw.Graph.HoverDetail.js
+++ b/src/js/Rickshaw.Graph.HoverDetail.js
@@ -60,9 +60,9 @@ Rickshaw.Graph.HoverDetail = Rickshaw.Class.create({
 
 			var domainIndexScale = d3.scale.linear()
 				.domain([data[0].x, data.slice(-1)[0].x])
-				.range([0, data.length]);
+				.range([0, data.length - 1]);
 
-			var approximateIndex = Math.floor(domainIndexScale(domainX));
+			var approximateIndex = Math.round(domainIndexScale(domainX));
 			var dataIndex = Math.min(approximateIndex || 0, data.length - 1);
 
 			for (var i = approximateIndex; i < data.length - 1;) {


### PR DESCRIPTION
The hover detail calculation makes it very difficult to hover over the next-to-last point in the series. You can easily see this in the lines example (http://code.shutterstock.com/rickshaw/examples/lines.html), just try to hover over the next-to-last point. I'm describing the same problem as issue #137, but, as you can see, it actually applies to all chart types.

Some more detail about the problem: Since the maximum of the linear scale is data.length instead of data.length - 1, hovering between the next-to-last and last points gives an approximateIndex of data.length - 1 instead of data.length - 2. This means the loop is never entered, and data.length - 1 is used as the dataIndex. Of course, by just changing the range of the linear scale to [0, data.length - 1], it wouldn't be possible to hover over the last point.

My solution is to simply hover over the _closest_ point instead of the previous one by using Math.round() instead of Math.floor(). Along with changing the range to [0, data.length - 1], I believe this solves the problem (including issue #137) in the general case.
