### PR TITLE
legend itens doesn't reflect disabled series on initial render

### DIFF
--- a/src/js/Rickshaw.Graph.Legend.js
+++ b/src/js/Rickshaw.Graph.Legend.js
@@ -24,6 +24,9 @@ Rickshaw.Graph.Legend = function(args) {
 	this.addLine = function (series) {
 		var line = document.createElement('li');
 		line.className = 'line';
+		if (series.disabled) {
+			line.className += ' disabled';
+		}
 
 		var swatch = document.createElement('div');
 		swatch.className = 'swatch';


### PR DESCRIPTION
This patch make the legend itens of disabled series appear disabled.
