### PR TITLE
Updated Rickshaw.Fixtures.Number.js to round formatted numbers.

### DIFF
--- a/src/js/Rickshaw.Fixtures.Number.js
+++ b/src/js/Rickshaw.Fixtures.Number.js
@@ -2,10 +2,10 @@ Rickshaw.namespace('Rickshaw.Fixtures.Number');
 
 Rickshaw.Fixtures.Number.formatKMBT = function(y) {
 	abs_y = Math.abs(y);
-	if (abs_y >= 1000000000000)   { return y / 1000000000000 + "T" } 
-	else if (abs_y >= 1000000000) { return y / 1000000000 + "B" } 
-	else if (abs_y >= 1000000)    { return y / 1000000 + "M" } 
-	else if (abs_y >= 1000)       { return y / 1000 + "K" }
+	if (abs_y >= 1000000000000)   { return (y / 1000000000000).toFixed(2) + "T" } 
+	else if (abs_y >= 1000000000) { return (y / 1000000000).toFixed(2) + "B" } 
+	else if (abs_y >= 1000000)    { return (y / 100000).toFixed(2)0 + "M" } 
+	else if (abs_y >= 1000)       { return (y / 1000).toFixed(2) + "K" }
 	else if (abs_y < 1 && y > 0)  { return y.toFixed(2) }
 	else if (abs_y == 0)          { return '' }
 	else                      { return y }
@@ -13,11 +13,11 @@ Rickshaw.Fixtures.Number.formatKMBT = function(y) {
 
 Rickshaw.Fixtures.Number.formatBase1024KMGTP = function(y) {
     abs_y = Math.abs(y);
-    if (abs_y >= 1125899906842624)  { return y / 1125899906842624 + "P" }
-    else if (abs_y >= 1099511627776){ return y / 1099511627776 + "T" }
-    else if (abs_y >= 1073741824)   { return y / 1073741824 + "G" }
-    else if (abs_y >= 1048576)      { return y / 1048576 + "M" }
-    else if (abs_y >= 1024)         { return y / 1024 + "K" }
+    if (abs_y >= 1125899906842624)  { return (y / 1125899906842624).toFixed(2) + "P" }
+    else if (abs_y >= 1099511627776){ return (y / 1099511627776).toFixed(2) + "T" }
+    else if (abs_y >= 1073741824)   { return (y / 1073741824).toFixed(2) + "G" }
+    else if (abs_y >= 1048576)      { return (y / 1048576).toFixed(2) + "M" }
+    else if (abs_y >= 1024)         { return (y / 1024).toFixed(2) + "K" }
     else if (abs_y < 1 && y > 0)    { return y.toFixed(2) }
     else if (abs_y == 0)            { return '' }
     else                        { return y }

--- a/src/js/Rickshaw.Fixtures.Number.js
+++ b/src/js/Rickshaw.Fixtures.Number.js
@@ -4,7 +4,7 @@ Rickshaw.Fixtures.Number.formatKMBT = function(y) {
 	abs_y = Math.abs(y);
 	if (abs_y >= 1000000000000)   { return (y / 1000000000000).toFixed(2) + "T" } 
 	else if (abs_y >= 1000000000) { return (y / 1000000000).toFixed(2) + "B" } 
-	else if (abs_y >= 1000000)    { return (y / 100000).toFixed(2)0 + "M" } 
+	else if (abs_y >= 1000000)    { return (y / 100000).toFixed(2) + "M" } 
 	else if (abs_y >= 1000)       { return (y / 1000).toFixed(2) + "K" }
 	else if (abs_y < 1 && y > 0)  { return y.toFixed(2) }
 	else if (abs_y == 0)          { return '' }


### PR DESCRIPTION
The goal is to avoid very long numbers, such as "190.73486328125M".

Another solution would be to use a function to change the argument of toFixed:

```
format = function(fixed) {
    return function(y) {
        ...
        (...).toFixed(fixed);
    }
};
```
