### PR TITLE
Fix HoverDetail to hover on second to last element

### DIFF
--- a/src/js/Rickshaw.Graph.HoverDetail.js
+++ b/src/js/Rickshaw.Graph.HoverDetail.js
@@ -60,15 +60,18 @@ Rickshaw.Graph.HoverDetail = Rickshaw.Class.create({
 
 			var domainIndexScale = d3.scale.linear()
 				.domain([data[0].x, data.slice(-1)[0].x])
-				.range([0, data.length]);
+				.range([0, data.length - 1]);
 
-			var approximateIndex = Math.floor(domainIndexScale(domainX));
-			var dataIndex = Math.min(approximateIndex || 0, data.length - 1);
+			var approximateIndex = Math.round(domainIndexScale(domainX));
+			var dataIndex = approximateIndex || 0;
 
 			for (var i = approximateIndex; i < data.length - 1;) {
 
 				if (!data[i] || !data[i + 1]) break;
-				if (data[i].x <= domainX && data[i + 1].x > domainX) { dataIndex = i; break }
+				if (data[i].x <= domainX && data[i + 1].x > domainX) {
+		                        dataIndex = i + ((2 * domainX - data[i].x < data[i + 1].x) ? 0 : 1);
+		                        break;
+		                }
 
 				if (data[i + 1].x <= domainX) { i++ } else { i-- }
 			}


### PR DESCRIPTION
Currently if you try to hover over the second to last element in a graph, it will only work if you are directly above it. If you are a pixel greater, it will snap to the last element.

This change will now snap the hover to a value closest to the data value rather than just the floor of the data value.

Eg where aI is the approximateIndex

case 1:
|   i                |
a1                   a2
in the case it will pick a1

case 2:
|               i    |
a1                   a2
in the case it will pick a2
