### PR TITLE
HoverDetail should use the point's pre-formatted X Y value instead of re-computing

### DIFF
--- a/src/js/Rickshaw.Graph.HoverDetail.js
+++ b/src/js/Rickshaw.Graph.HoverDetail.js
@@ -151,8 +151,8 @@ Rickshaw.Graph.HoverDetail = Rickshaw.Class.create({
 
 		if (point.value.y === null) return;
 
-		var formattedXValue = this.xFormatter(point.value.x);
-		var formattedYValue = this.yFormatter(point.value.y);
+		var formattedXValue = point.formattedXValue;
+		var formattedYValue = point.formattedYValue;
 
 		this.element.innerHTML = '';
 		this.element.style.left = graph.x(point.value.x) + 'px';


### PR DESCRIPTION
see change in src/js/Rickshaw.Graph.HoverDetail.js
