### PR TITLE
Added node_modules and minified JS skipping to .jshintignore

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,2 +1,5 @@
+node_modules/
+**/vendor/
+**/*[.-]min.js
 src/js/Rickshaw.Class.js
 src/js/Rickshaw.Compat.ClassList.js


### PR DESCRIPTION
JSHint shows a number of errors for rickshaw, but I was able to cut out most of them by tweaking `.jshintignore`.

The rest look like this:

```
$ jshint .
examples\js\extensions.js: line 46, col 6, Missing semicolon.

rickshaw.js: line 131, col 4, Missing semicolon.
rickshaw.js: line 148, col 4, Missing semicolon.
rickshaw.js: line 168, col 25, Unnecessary semicolon.
rickshaw.js: line 184, col 29, Missing '()' invoking a constructor.
...
tests\Rickshaw.Series.js: line 65, col 2, Missing semicolon.
tests\Rickshaw.Series.js: line 74, col 2, Missing semicolon.
tests\Rickshaw.Series.js: line 95, col 2, Missing semicolon.
tests\Rickshaw.Series.js: line 113, col 2, Missing semicolon.
tests\Rickshaw.Series.js: line 131, col 2, Missing semicolon.
tests\Rickshaw.Series.js: line 149, col 2, Missing semicolon.

59 errors
```

I left these alone for the rickshaw team to decide how to resolve.
