### PR TITLE
Added an extra validation rule to the series validation - for 0-length data

### DIFF
--- a/src/js/Rickshaw.Graph.js
+++ b/src/js/Rickshaw.Graph.js
@@ -76,7 +76,10 @@ Rickshaw.Graph = function(args) {
 			if (!Array.isArray(s.data)) {
 				throw "series data is not an array: " + JSON.stringify(s.data);
 			}
-
+			if (s.data.length === 0) {
+				throw "series data is an empty array";
+			}
+			
 			var x = s.data[0].x;
 			var y = s.data[0].y;
 


### PR DESCRIPTION
Providing a series with no data causes a `TypeError: Cannot read property 'x' of undefined` as the validator goes on to check x/y of the first element (which may not exist).
