### PR TITLE
Multiple normalized series causes "seriesData.forEach not defined"-Excep...

### DIFF
--- a/src/js/Rickshaw.Graph.js
+++ b/src/js/Rickshaw.Graph.js
@@ -146,9 +146,11 @@ Rickshaw.Graph = function(args) {
 			if (series.scale) {
 				// apply scale to each series
 				var seriesData = data[index];
-				seriesData.forEach( function(d) {
-					d.y = series.scale(d.y);
-				} );
+				if(seriesData) {
+					seriesData.forEach( function(d) {
+						d.y = series.scale(d.y);
+					} );
+				}
 			}
 		} );
 


### PR DESCRIPTION
...tion

Because seriesData is null at this point. The data does contain less elements than this.series. 
btw: Iterating over an array with the index of another array seems dangerous to me. So my quick fix won't be the best one anyway.

Example code can be found here: https://github.com/unSinn/plant-vertx/blob/master/webroot/js/plant.js
