### PR TITLE
Delayed validation in Rickshaw.Graph.Renderer.Multi

### DIFF
--- a/src/js/Rickshaw.Graph.Renderer.Multi.js
+++ b/src/js/Rickshaw.Graph.Renderer.Multi.js
@@ -7,12 +7,6 @@ Rickshaw.Graph.Renderer.Multi = Rickshaw.Class.create( Rickshaw.Graph.Renderer, 
 	initialize: function($super, args) {
 
 		$super(args);
-
-		this.graph.series.forEach( function(series) {
-			if (!series.renderer) {
-				throw new Error("Each series needs a renderer for graph 'multi' renderer");
-			}
-		});
 	},
 
 	defaults: function($super) {
@@ -120,6 +114,12 @@ Rickshaw.Graph.Renderer.Multi = Rickshaw.Class.create( Rickshaw.Graph.Renderer, 
 	},
 
 	render: function() {
+
+		this.graph.series.forEach( function(series) {
+			if (!series.renderer) {
+				throw new Error("Each series needs a renderer for graph 'multi' renderer");
+			}
+		});
 
 		this.graph.vis.selectAll('*').remove();
 


### PR DESCRIPTION
While I'm really quite fond of validation and performing it early to ensure that any constraint violations fail fast, unfortunately the check for all the series having a renderer if the graph 'multi' renderer is used cannot be performed in the initialize of the renderer as all graphs will create an instance of the renderer even if it isn't used.  This can be seen by performing:

make clean build

and then npm test
