### PR TITLE
(Resubmit) Allow hover to work for non-uniformly spaced X values.

### DIFF
--- a/src/js/Rickshaw.Graph.HoverDetail.js
+++ b/src/js/Rickshaw.Graph.HoverDetail.js
@@ -55,14 +55,13 @@ Rickshaw.Graph.HoverDetail = Rickshaw.Class.create({
 		this.graph.series.active().forEach( function(series) {
 
 			var data = this.graph.stackedData[j++];
-
 			var domainX = graph.x.invert(eventX);
 
 			var inputDomainNumbers = [];
-
 			var scaleOutputRange = [];
+			var i;
 
-			for (var i = 0; i < data.length; i++) {
+			for (i = 0; i < data.length; i++) {
 				inputDomainNumbers.push(data[i].x);
 				scaleOutputRange.push(i);
 			}
@@ -74,7 +73,7 @@ Rickshaw.Graph.HoverDetail = Rickshaw.Class.create({
 			var approximateIndex = Math.round(domainIndexScale(domainX));
 			var dataIndex = Math.min(approximateIndex || 0, data.length - 1);
 
-			for (var i = approximateIndex; i < data.length - 1;) {
+			for (i = approximateIndex; i < data.length - 1;) {
 
 				if (!data[i] || !data[i + 1]) break;
 


### PR DESCRIPTION
While graphing a data set with X values that were not uniformly spaced I found that I was unable to hover over some datapoints. The root of this issue is that d3.scale.linear()'s range() and domain() were taking the minimum and maximum values and then returning an index uniformly spaced between data points. Rather than passing the minimum and maximum values we can pass in discrete values for both the input and output. This allows us to hover over all data points regardless of spacing.

For example, if we graphed the following series, this issue would prohibit us from hovering over the 380 datapoint: [0,100,200,300,380,400]

I started to look at Rickshaw's test system, but I got stumped on this error "Error: Wrong document."

Note: I closed the original pull request because I messed up my local branching: https://github.com/shutterstock/rickshaw/pull/263
