### PR TITLE
When resizing the graph the appropriate number of ticks on the X axis are not recomputed when using Rickshaw.Graph.Axis.X.

### DIFF
--- a/src/js/Rickshaw.Graph.Axis.X.js
+++ b/src/js/Rickshaw.Graph.Axis.X.js
@@ -10,8 +10,6 @@ Rickshaw.Graph.Axis.X = function(args) {
 		this.graph = args.graph;
 		this.orientation = args.orientation || 'top';
 
-		var pixelsPerTick = args.pixelsPerTick || 75;
-		this.ticks = args.ticks || Math.floor(this.graph.width / pixelsPerTick);
 		this.tickSize = args.tickSize || 4;
 		this.ticksTreatment = args.ticksTreatment || 'plain';
 
@@ -59,6 +57,9 @@ Rickshaw.Graph.Axis.X = function(args) {
 
 		var axis = d3.svg.axis().scale(this.graph.x).orient(this.orientation);
 		axis.tickFormat( args.tickFormat || function(x) { return x } );
+    
+		var pixelsPerTick = args.pixelsPerTick || 75;
+		this.ticks = args.ticks || Math.floor(this.graph.width / pixelsPerTick);
 
 		var berth = Math.floor(this.width * berthRate / 2) || 0;
 		var transform;


### PR DESCRIPTION
The issue can be replicated when we do something like this:

graph = new Rickshaw.Graph( { width: 850, ...} );
graph.render();

... the user resizes the window and we want to resize the graph:

graph.configure({width: 100});
graph.render();

As of now, the appropriate number of ticks for the X axis are not re-computed, which results in a very weird looking axis in some cases.
