### PR TITLE
Set default `magnitude` on `frequentInterval`

### DIFF
--- a/src/js/Rickshaw.Graph.Renderer.Bar.js
+++ b/src/js/Rickshaw.Graph.Renderer.Bar.js
@@ -95,7 +95,7 @@ Rickshaw.Graph.Renderer.Bar = Rickshaw.Class.create( Rickshaw.Graph.Renderer, {
 			intervalCounts[interval]++;
 		}
 
-		var frequentInterval = { count: 0 };
+		var frequentInterval = { count: 0, magnitude: 1 };
 
 		Rickshaw.keys(intervalCounts).forEach( function(i) {
 			if (frequentInterval.count < intervalCounts[i]) {


### PR DESCRIPTION
When only one item is in the graph, the `_frequentInterval` function
returns an object without a magnitude, and `barWidth` returns
`NaN` as a result.
