### PR TITLE
Update Rickshaw.Graph.js

### DIFF
--- a/src/js/Rickshaw.Graph.js
+++ b/src/js/Rickshaw.Graph.js
@@ -143,7 +143,7 @@ Rickshaw.Graph = function(args) {
 
 		data = preserve ? Rickshaw.clone(data) : data;
 
-		this.series.forEach( function(series, index) {
+		this.series.active().forEach( function(series, index) {
 			if (series.scale) {
 				// apply scale to each series
 				var seriesData = data[index];


### PR DESCRIPTION
Fixing an apparent bug in this.stackData: when we are toggling between series of different scales the data[index] access at line 149 can hit an array out-of-bounds error if there are inactive series.  Added active() to the call at line 146, to parallel the call at line 130.  This seems to fix the issue.
