### PR TITLE
allows injection of time fixtures to axis

### DIFF
--- a/src/js/Rickshaw.Graph.Axis.Time.js
+++ b/src/js/Rickshaw.Graph.Axis.Time.js
@@ -9,7 +9,7 @@ Rickshaw.Graph.Axis.Time = function(args) {
 	this.ticksTreatment = args.ticksTreatment || 'plain';
 	this.fixedTimeUnit = args.timeUnit;
 
-	var time = new Rickshaw.Fixtures.Time();
+	var time = args.timeFixture || new Rickshaw.Fixtures.Time();
 
 	this.appropriateTimeUnit = function() {
 


### PR DESCRIPTION
This could make it much easier to use a different time fixture, whilst retaining backwards compatibility if no fixture is provided.

Related to https://github.com/shutterstock/rickshaw/issues/140#issuecomment-21154192, however the suggestion in the comment would force using a `fixedTimeUnit` that won't get re-calculated if the graph gets updated.

Being able to inject a different time fixture makes it very easy to, e.g. overwrite the `formatTime` or `formatDate` functions and feed those to the axis easily.
