### PR TITLE
Add "maxTicks" parameter to Rickshaw's time axis.

### DIFF
--- a/src/js/Rickshaw.Graph.Axis.Time.js
+++ b/src/js/Rickshaw.Graph.Axis.Time.js
@@ -8,6 +8,7 @@ Rickshaw.Graph.Axis.Time = function(args) {
 	this.elements = [];
 	this.ticksTreatment = args.ticksTreatment || 'plain';
 	this.fixedTimeUnit = args.timeUnit;
+	this.maxTicks = args.maxTicks;
 
 	var time = new Rickshaw.Fixtures.Time();
 
@@ -38,6 +39,19 @@ Rickshaw.Graph.Axis.Time = function(args) {
 		var runningTick = domain[0];
 
 		var offsets = [];
+
+		if (this.maxTicks && count > this.maxTicks) {
+			var interval = time.ceil((domain[1] - domain[0]) / maxTicks, unit);
+
+			for (var i = 0; i < this.maxTicks; i++) {
+				var tickValue = Math.ceil(runningTick / interval) * interval;
+				runningTick = tickValue + interval;
+
+				offsets.push( { value: tickValue, unit: unit });
+			}
+
+			count = 0;
+		}		
 
 		for (var i = 0; i < count; i++) {
 


### PR DESCRIPTION
Accept a new parameter, maxTicks, that allows users to say how many time-axis tick marks should be on a graph.
![no maximum ticks](https://f.cloud.github.com/assets/2722306/844868/4ffecf38-f3db-11e2-863c-674a3d8718d7.png)
![maximum tick size is 4](https://f.cloud.github.com/assets/2722306/844869/5015d714-f3db-11e2-8fe6-34c995c90b97.png)
