### PR TITLE
Add "make test" target to install prereqs for "npm test" to work.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ NODE_MODULES=$(NODE_PREFIX)/node_modules
 CSS_MIN=$(NODE_MODULES)/.bin/cleancss
 JS_MIN=$(NODE_MODULES)/.bin/uglifyjs
 JS_HINT=$(NODE_MODULES)/.bin/jshint
+D3=$(NODE_MODULES)/d3
+JSDOM=$(NODE_MODULES)/jsdom
+NODEUNIT=$(NODE_MODULES)/nodeunit
 
 CSS_FILES=\
 	src/css/detail.css\
@@ -52,6 +55,9 @@ build: rickshaw.min.css rickshaw.min.js
 clean:
 	rm -rf rickshaw.css rickshaw.js rickshaw.min.*
 
+test: $(D3) $(JSDOM) $(NODEUNIT)
+	npm test
+
 $(JS_HINT):
 	npm install jshint
 
@@ -60,6 +66,15 @@ $(CSS_MIN):
 
 $(JS_MIN):
 	npm install uglify-js
+
+$(D3):
+	npm install d3
+
+$(JSDOM):
+	npm install jsdom
+
+$(NODEUNIT):
+	npm install nodeunit
 
 rickshaw.css: $(CSS_FILES)
 	cat $(CSS_FILES) > rickshaw.css


### PR DESCRIPTION
Adds a "make test" target so that people don't need to manually figure out how to get "npm test" working.

Test plan:
- cd to your rickshaw checkout
- `make build`
- `rm -rf node_modules`
- Verify that `npm test` fails for lack of dependencies. If it doesn't you may need to remove the d3, jsdom or nodeunit modules from your global npm repository.
- Run `make test`, verify that it installed the test dependencies and than ran the rickshaw unit tests.
- Run `make test` again, verify that it didn't need to install anything and that it ran the rickshaw unit tests again.
- Run `npm test` manually, check it still works ok.

Test plan works fine on my local machine. :)
