### PR TITLE
Autodiscover renderers rather than use hard-coded list.

### DIFF
--- a/src/js/Rickshaw.Graph.js
+++ b/src/js/Rickshaw.Graph.js
@@ -39,19 +39,12 @@ Rickshaw.Graph = function(args) {
 			.attr('width', this.width)
 			.attr('height', this.height);
 
-		var renderers = [
-			Rickshaw.Graph.Renderer.Stack,
-			Rickshaw.Graph.Renderer.Line,
-			Rickshaw.Graph.Renderer.Bar,
-			Rickshaw.Graph.Renderer.Area,
-			Rickshaw.Graph.Renderer.ScatterPlot,
-			Rickshaw.Graph.Renderer.Multi
-		];
-
-		renderers.forEach( function(r) {
-			if (!r) return;
+		for (var name in Rickshaw.Graph.Renderer) {
+			if (!name || !Rickshaw.Graph.Renderer.hasOwnProperty(name)) continue;
+			var r = Rickshaw.Graph.Renderer[name];
+			if (!r || !r.prototype || !r.prototype.render) continue;
 			self.registerRenderer(new r( { graph: self } ));
-		} );
+		}
 
 		this.setRenderer(args.renderer || 'stack', args);
 		this.discoverRange();

--- a/tests/Rickshaw.Graph.js
+++ b/tests/Rickshaw.Graph.js
@@ -113,3 +113,59 @@ exports.inconsistent = function(test) {
 
 	test.done();
 };
+
+exports.rendererAutodiscover = function(test) {
+
+	var jsdom    = require("jsdom").jsdom;
+	global.document = jsdom("<html><head></head><body></body></html>");
+	global.window   = global.document.createWindow();
+
+	var Rickshaw = require('../rickshaw');
+	new Rickshaw.Compat.ClassList();
+
+	var el = document.createElement("div");
+
+	var series = [
+		{
+			color: 'steelblue',
+			data: [ { x: 0, y: 40 }, { x: 1, y: 49 }, { x: 2, y: 38 } ]
+		}, {
+			color: 'red',
+			data: [ { x: 0, y: 40 }, { x: 1, y: 49 }, { x: 2, y: 38 } ]
+		}
+	];
+
+	test.throws( function() {
+
+		var graph = new Rickshaw.Graph({
+			element: el,
+			width: 960,
+			height: 500,
+			renderer: 'testline',
+			series: series
+		});
+
+	}, null, "throw for unknown renderer" );
+
+	Rickshaw.namespace('Rickshaw.Graph.Renderer.TestLine');
+
+	Rickshaw.Graph.Renderer.TestLine = Rickshaw.Class.create( Rickshaw.Graph.Renderer.Line, {
+		name: 'testline'
+	} );
+
+	test.doesNotThrow( function() {
+
+		var graph = new Rickshaw.Graph({
+			element: el,
+			width: 960,
+			height: 500,
+			renderer: 'testline',
+			series: series
+		});
+
+	}, "new render autodiscovered ok" );
+
+	delete Rickshaw.Graph.Renderer.TestLine;
+
+	test.done();
+};


### PR DESCRIPTION
Finds renderers automatically under the Rickshaw.Graph.Renderer namespace rather than using a hard-coded list within Rickshaw.Graph's initialize.

Allows third-party developers to produce new renderers without having to modify their rickshaw.js and have merge conflicts when they upgrade.

Implementation is a bit hacky, there's probably a cleaner way, but it's an improvement over the existing inaccessible hard-coded list.

Test Plan:
- cd to your rickshaw repo
- checkout master
- `make build` to get a version of rickshaw.js without the patch applied.
- check out the patch branch, making sure you carry over the master version of rickshaw.js
- `npm test` and verify that the new unit test fails on the unpatched rickshaw.js
- `make build` to get a version of rickshaw.js with the patch applied.
- `npm test` and verify that the new unit test passes on the patched rickshaw.js.

Test plan has been tried and passes on my local repo.
