### PR TITLE
Uncaught TypeError: Cannot read property 'style' of undefined

### DIFF
--- a/src/js/Rickshaw.Graph.RangeSlider.js
+++ b/src/js/Rickshaw.Graph.RangeSlider.js
@@ -49,7 +49,7 @@ Rickshaw.Graph.RangeSlider = Rickshaw.Class.create({
 			} );
 		} );
 
-		element[0].style.width = graph.width + 'px';
+		element.style.width = graph.width + 'px';
 	},
 
 	update: function() {


### PR DESCRIPTION
"element[0].style.width" does not exist, causes a uncaught type error. Using "element.style.width" fixes the problem
