### PR TITLE
Add a class to the main graph svg

### DIFF
--- a/src/js/Rickshaw.Graph.js
+++ b/src/js/Rickshaw.Graph.js
@@ -37,7 +37,8 @@ Rickshaw.Graph = function(args) {
 		this.vis = d3.select(this.element)
 			.append("svg:svg")
 			.attr('width', this.width)
-			.attr('height', this.height);
+			.attr('height', this.height)
+			.attr('class', 'rickshaw_graph graph');
 
 		for (var name in Rickshaw.Graph.Renderer) {
 			if (!name || !Rickshaw.Graph.Renderer.hasOwnProperty(name)) continue;


### PR DESCRIPTION
Add a class to the main graph svg making selection of this element easier for adding custom annotations with d3 on the svg layer.
