### PR TITLE
Fix two bugs: Time.Ceil and Drawing Ticks

### DIFF
--- a/rickshaw.js
+++ b/rickshaw.js
@@ -944,11 +944,16 @@ Rickshaw.Fixtures.Time = function() {
 
 		if (unit.name == 'month') {
 
-			nearFuture = new Date((time + unit.seconds - 1) * 1000);
+			cur_time = new Date(time * 1000);
 
 			rounded = new Date(0);
-			rounded.setUTCFullYear(nearFuture.getUTCFullYear());
-			rounded.setUTCMonth(nearFuture.getUTCMonth());
+			if(cur_time.getUTCMonth() >= 11) {
+				rounded.setUTCFullYear(cur_time.getUTCFullYear()+1);
+				rounded.setUTCMonth(0);
+			} else {
+				rounded.setUTCFullYear(cur_time.getUTCFullYear());
+				rounded.setUTCMonth(cur_time.getUTCMonth()+1);
+			}
 			rounded.setUTCDate(1);
 			rounded.setUTCHours(0);
 			rounded.setUTCMinutes(0);
@@ -1402,6 +1407,12 @@ Rickshaw.Graph.Axis.Time = function(args) {
 		var runningTick = domain[0];
 
 		var offsets = [];
+
+		// Check if the tick falls exactly on the first point
+		if(time.ceil(runningTick-1, unit) == runningTick) {
+			offsets.push( { value: runningTick, unit: unit } );
+			count--;
+		}
 
 		for (var i = 0; i < count; i++) {
 


### PR DESCRIPTION
This commit fixes two bugs:
1 - The ceiling function does not properly work for months with only 30 days in them and where the input time is on the first of the month. This is because it added 30.5 days to the start time instead of properly counting the days in the month. The fix was relatively straightforward.
2 - When drawing ticks, fix an off-by-one error if the tick falls exactly on the first pixel. It would previously not draw the first tick and instead draw a second one at the end.

Without fixing these bugs, you could end up with ticks that were shifted to the right as in the figure below:
![image](https://f.cloud.github.com/assets/671052/1484053/6c4fdfe6-4701-11e3-8c61-163db1b9f8fa.png)
