### PR TITLE
Add xScale parameter to Graph

### DIFF
--- a/src/js/Rickshaw.Graph.js
+++ b/src/js/Rickshaw.Graph.js
@@ -104,7 +104,11 @@ Rickshaw.Graph = function(args) {
 
 		var domain = this.renderer.domain();
 
-		var xScale = this.xScale || d3.scale.linear();
+		// this.xScale is coming from the configuration dictionary
+		// which may be referenced by the Graph creator, or shared
+		// with other Graphs. We need to ensure we copy the scale
+		// so that our mutations do not change the object given to us.
+		var xScale = (this.xScale || d3.scale.linear()).copy();
 		this.x = xScale.domain(domain.x).range([0, this.width]);
 
 		this.y = d3.scale.linear().domain(domain.y).range([this.height, 0]);

--- a/tests/Rickshaw.Graph.js
+++ b/tests/Rickshaw.Graph.js
@@ -91,11 +91,12 @@ exports.timeScale = function(test) {
 		}
 	];
 
+	var scale = d3.time.scale();
 	var graph = new Rickshaw.Graph({
 		element: el,
 		width: 960,
 		height: 500,
-		xScale: d3.time.scale(),
+		xScale: scale,
 		series: series
 	});
 	graph.render();
@@ -110,6 +111,12 @@ exports.timeScale = function(test) {
 	test.equal('Sep 29', ticks[0].innerHTML);
 	test.equal('Oct 06', ticks[1].innerHTML);
 	test.equal('Nov 24', ticks[8].innerHTML);
+	
+	// should make a copy mutable object
+	scale.range([0, 960]);
+	test.deepEqual(scale.range(), graph.x.range());
+	scale.range([0, 1])
+	test.notDeepEqual(scale.range(), graph.x.range());
 
 	test.done();
 


### PR DESCRIPTION
By creating Rickshaw.Graph({xScale: d3.time.scale()}), users can now
instantiate a Graph with a linear scale that has Date objects as
domain values. This way, a regular Axis.X can render time using D3's
time formatter:

```
var xAxis = new Rickshaw.Graph.Axis.X({
    graph: graph,
    tickFormat: graph.x.tickFormat()
});
```
