### PR TITLE
Add series configured class name to all scatterplot points

### DIFF
--- a/src/js/Rickshaw.Graph.Renderer.ScatterPlot.js
+++ b/src/js/Rickshaw.Graph.Renderer.ScatterPlot.js
@@ -39,10 +39,13 @@ Rickshaw.Graph.Renderer.ScatterPlot = Rickshaw.Class.create( Rickshaw.Graph.Rend
 			var nodes = vis.selectAll("path")
 				.data(series.stack.filter( function(d) { return d.y !== null } ))
 				.enter().append("svg:circle")
-				.attr("cx", function(d) { return graph.x(d.x) })
-				.attr("cy", function(d) { return graph.y(d.y) })
-				.attr("r", function(d) { return ("r" in d) ? d.r : dotSize});
-
+					.attr("cx", function(d) { return graph.x(d.x) })
+					.attr("cy", function(d) { return graph.y(d.y) })
+					.attr("r", function(d) { return ("r" in d) ? d.r : dotSize});
+			if (series.className) {
+				nodes.classed(series.className, true);
+			}
+			
 			Array.prototype.forEach.call(nodes[0], function(n) {
 				n.setAttribute('fill', series.color);
 			} );

--- a/tests/Rickshaw.Graph.Renderer.Scatterplot.js
+++ b/tests/Rickshaw.Graph.Renderer.Scatterplot.js
@@ -1,0 +1,29 @@
+var Rickshaw = require("../rickshaw");
+
+exports["should add the series className to all scatterplot points"] = function(test) {
+	var el = document.createElement("div");
+	var graph = new Rickshaw.Graph({
+		element: el,
+		stroke: true,
+		width: 10,
+		height: 10,
+		renderer: 'scatterplot',
+		series: [
+			{
+				className: 'fnord',
+				data: [
+					{ x: 0, y: 40 },
+					{ x: 1, y: 49 },
+					{ x: 2, y: 38 },
+					{ x: 3, y: 30 },
+					{ x: 4, y: 32 }
+				]
+			}
+		]
+	});
+	graph.render()
+	
+	var path = graph.vis.selectAll('circle.fnord')
+	test.equals(5, path.size())
+	test.done()
+}


### PR DESCRIPTION
This fixes an inconsistency where the configured classname from the series is not set by this plot.
