### PR TITLE
Force content to overflow containing div and not be hidden

### DIFF
--- a/src/css/graph.css
+++ b/src/css/graph.css
@@ -2,6 +2,7 @@
 
 .rickshaw_graph {
 	position: relative;
+	overflow: visible;
 }
 .rickshaw_graph svg {
 	display: block;	


### PR DESCRIPTION
Hi,

This might be me doing something wrong, but I have found that when displaying a y-axis in a separate div, that the content does not display correctly unless the containing div's height is tall enough for the axis labels (the div does not expand to the content). Whilst I could specify the containing div's height (to be the same as the graph), it would be better if that wasn't necessary.

You can see the problem here: http://jsfiddle.net/SSkHD/ (this is based on the main y-axis example, except I have removed the absolute div positioning).

This seems to be because an overflow:hidden is being inherited from somewhere (I couldn't work out where - it's not the svg block). I have found that adding overflow:visible to .rickshaw_graph works (as per this pull request), but I'm not sure whether this will adversely affect anything else. Removing the overflow:hidden from ".rickshaw_graph svg" does not work, and I assume that is there for a reason anyway).

Thanks,

Andy
