### PR TITLE
Ensure Graph creates a copy of the x/yScale before modifying it

### DIFF
--- a/src/js/Rickshaw.Graph.js
+++ b/src/js/Rickshaw.Graph.js
@@ -105,8 +105,13 @@ Rickshaw.Graph = function(args) {
 
 		var domain = this.renderer.domain();
 
-		this.x = (this.xScale || d3.scale.linear()).domain(domain.x).range([0, this.width]);
-		this.y = (this.yScale || d3.scale.linear()).domain(domain.y).range([this.height, 0]);
+		// this.*Scale is coming from the configuration dictionary
+		// which may be referenced by the Graph creator, or shared
+		// with other Graphs. We need to ensure we copy the scale
+		// so that our mutations do not change the object given to us.
+		// Hence the .copy()
+		this.x = (this.xScale || d3.scale.linear()).copy().domain(domain.x).range([0, this.width]);
+		this.y = (this.yScale || d3.scale.linear()).copy().domain(domain.y).range([this.height, 0]);
 
 		this.y.magnitude = d3.scale.linear()
 			.domain([domain.y[0] - domain.y[0], domain.y[1] - domain.y[0]])

--- a/tests/Rickshaw.Graph.js
+++ b/tests/Rickshaw.Graph.js
@@ -92,11 +92,12 @@ exports.scales = function(test) {
 		}
 	];
 
+	var scale = d3.time.scale();
 	var graph = new Rickshaw.Graph({
 		element: el,
 		width: 960,
 		height: 500,
-		xScale: d3.time.scale(),
+		xScale: scale,
 		yScale: d3.scale.sqrt(),
 		series: series
 	});
@@ -117,7 +118,6 @@ exports.scales = function(test) {
 	yAxis.render();
 
 	test.ok(graph.x.ticks()[0] instanceof Date);
-
 	var xTicks = el.getElementsByClassName('x_ticks_d3')[0].getElementsByTagName('text');
 	test.equal(xTicks[0].innerHTML, 'Sep 29');
 	test.equal(xTicks[1].innerHTML, 'Oct 06');
@@ -128,6 +128,12 @@ exports.scales = function(test) {
 	test.equal(yTicks[1].getAttribute('transform'), 'translate(0,275.24400874015976)');
 	test.equal(yTicks[2].getAttribute('transform'), 'translate(0,182.14702893572513)');
 
+	// should make a copy mutable object
+	scale.range([0, 960]);
+	test.deepEqual(scale.range(), graph.x.range());
+	scale.range([0, 1])
+	test.notDeepEqual(scale.range(), graph.x.range());
+	
 	test.done();
 };
 


### PR DESCRIPTION
x/yScale is coming from the configuration dictionary which may be
referenced by the Graph creator, or shared with other Graphs. We need to
ensure we copy the scale so that our mutations do not change the object
given to us.
