### PR TITLE
Fix size(width) of graph (preview) container

### DIFF
--- a/src/js/Rickshaw.Graph.RangeSlider.Preview.js
+++ b/src/js/Rickshaw.Graph.RangeSlider.Preview.js
@@ -121,6 +121,8 @@ Rickshaw.Graph.RangeSlider.Preview = Rickshaw.Class.create({
 		var translateCommand = "translate(" +
 			this.config.frameHandleThickness + "px, " +
 			this.config.frameTopThickness + "px)";
+			
+		var widthCommand = this.previewWidth + "px";
 
 		graphContainer.enter()
 			.append("div")
@@ -129,6 +131,7 @@ Rickshaw.Graph.RangeSlider.Preview = Rickshaw.Class.create({
 			.style("-moz-transform", translateCommand)
 			.style("-ms-transform", translateCommand)
 			.style("transform", translateCommand)
+			.style("width", widthCommand)
 			.each(buildGraph);
 
 		graphContainer.exit()


### PR DESCRIPTION
When the preview (.RangeSlider.Preview) width is customised, the container for the graph was not updated accordingly.

For eg: when the width is set to be larger than the graph there is some whitespace on the right end. The graph has been generated to the correct size, but the container was restricting the display.
