### PR TITLE
Fine tuning for the detail dot

### DIFF
--- a/src/css/detail.css
+++ b/src/css/detail.css
@@ -88,7 +88,7 @@
 	width: 4px;
 	height: 4px;
 	margin-left: -3px;
-	margin-top: -3px;
+	margin-top: -3.5px;
 	border-radius: 5px;
 	position: absolute;
 	box-shadow: 0 0 2px rgba(0, 0, 0, 0.6);


### PR DESCRIPTION
This change does two things:
- recenters the 'dot'
- explicitly states the boundary box.

The dot was misaligned by 1 pixel. Before this change: 
![2014-02-12 11_04_01-code shutterstock com_rickshaw_examples_lines html](https://f.cloud.github.com/assets/5855248/2147640/7f520526-93d5-11e3-8f8e-32273bfc9b67.png)

And after: 
![2014-02-12 11_03_23-code shutterstock com_rickshaw_examples_lines html](https://f.cloud.github.com/assets/5855248/2147643/8a375252-93d5-11e3-9bf7-365530a295b5.png)

The second thing this change does is explicitly states the box-sizing as content-box. This is the default, but it can be changed by upstream CSS (eg: bootstrap). I was finding that with bootstrap the dot would appear as a small filled dot rather than the hollow dot.
