### PR TITLE
Don't override custom domain set on x/yScale option

### DIFF
--- a/rickshaw.js
+++ b/rickshaw.js
@@ -486,13 +486,27 @@ Rickshaw.Graph = function(args) {
 
 		var domain = this.renderer.domain();
 
-		this.x = (this.xScale || d3.scale.linear()).domain(domain.x).range([0, this.width]);
-		this.y = (this.yScale || d3.scale.linear()).domain(domain.y).range([this.height, 0]);
+		var xScale = this.xScale || d3.scale.linear();
+		// Set domain unless already set
+		if (isDefaultDomain(xScale.domain())) {
+		    xScale = xScale.domain(domain.x);
+		}
+		this.x = xScale.range([0, this.width]);
+
+		var yScale = this.yScale || d3.scale.linear();
+		if (isDefaultDomain(yScale.domain())) {
+		    yScale = yScale.domain(domain.y);
+		}
+		this.y = yScale.range([this.height, 0]);
 
 		this.y.magnitude = d3.scale.linear()
 			.domain([domain.y[0] - domain.y[0], domain.y[1] - domain.y[0]])
 			.range([0, this.height]);
 	};
+
+        function isDefaultDomain(domain) {
+            return domain[0] === 0 && domain[1] === 1;
+        }
 
 	this.render = function() {
 


### PR DESCRIPTION
I'm graphing data with sparse datapoints, but I want to fix the domain of the graph to match a given query, rather than discovering the domain based on the presence of data points.

For that, I had to use a custom `xScale`. The current code overrides the domain and range of the custom `xScale` though, so this PR changes the code to only override the domain if it wasn't set externally.

There might be a better way to do this, but that was the simplest I found. Feedback welcome!
