### PR TITLE
Prevent selecting no data with RangeSlider

### DIFF
--- a/src/js/Rickshaw.Graph.RangeSlider.js
+++ b/src/js/Rickshaw.Graph.RangeSlider.js
@@ -34,7 +34,8 @@ Rickshaw.Graph.RangeSlider = Rickshaw.Class.create({
 				],
 				slide: function( event, ui ) {
 
-					if (ui.values[1] <= ui.values[0]) return;
+					step = graph.series[0].data[1].x - graph.series[0].data[0].x
+					if (ui.values[1] <= ui.values[0] + step) return;
 
 					graph.window.xMin = ui.values[0];
 					graph.window.xMax = ui.values[1];


### PR DESCRIPTION
In addition to preventing the range slider from overlapping, make it so that it always has at least one point of data displayed. Otherwise, all data from graph could disappear.

Only uses the step from the first series on the graph though. Unsure how prudent it would be to get the largest (or smallest) step for all series to use as the limit. 
