### PR TITLE
Correct minor mistake with default radio button

### DIFF
--- a/tutorial/example_07.html
+++ b/tutorial/example_07.html
@@ -32,9 +32,9 @@
 	<div id="chart"></div>
 	<div id="legend"></div>
 	<form id="offset_form" class="toggler">
-		<input type="radio" name="offset" id="lines" value="lines" checked>
+		<input type="radio" name="offset" id="lines" value="lines">
 		<label class="lines" for="lines">lines</label><br>
-		<input type="radio" name="offset" id="stack" value="zero">
+		<input type="radio" name="offset" id="stack" value="zero" checked>
 		<label class="stack" for="stack">stack</label>
 	</form>
 </div>


### PR DESCRIPTION
Example starts with stacked selected, but checked is set on lines
