### PR TITLE
Use configs if they already exist on configure RangeSlider.Preview

### DIFF
--- a/src/js/Rickshaw.Graph.RangeSlider.Preview.js
+++ b/src/js/Rickshaw.Graph.RangeSlider.Preview.js
@@ -57,19 +57,12 @@ Rickshaw.Graph.RangeSlider.Preview = Rickshaw.Class.create({
 				: this.defaults[k];
 		}, this);
 
-		if (args.width) {
-			this.previews.forEach(function(preview) {
-				var width = args.width - this.config.frameHandleThickness * 2;
-				preview.setSize({ width: width });
-			}, this);
-		}
+		this.previews.forEach(function(preview) {
+			var height = this.previewHeight / this.graphs.length;
+			var width = args.width - this.config.frameHandleThickness * 2;
+			preview.setSize({ width: width, height: height });
+		}, this);
 
-		if (args.height) {
-			this.previews.forEach(function(preview) {
-				var height = this.previewHeight / this.graphs.length;
-				preview.setSize({ height: height });
-			}, this);
-		}
 	},
 
 	render: function() {


### PR DESCRIPTION
Fixes most of #375

When re-running configure, such as when manually changing the slider width (as per the issue), the configurations set in the initialization of the object aren't restored, but reset to scratch, only to be repopulated with the defaults.

This fix uses the same logic per Rickshaw.Graph.js:249, where `this.config` is only initialized as an empty object if it doesn't already exist. 
