### PR TITLE
Removed trailing comma in example

### DIFF
--- a/examples/y_axis.html
+++ b/examples/y_axis.html
@@ -52,7 +52,7 @@ var y_ticks = new Rickshaw.Graph.Axis.Y( {
 	graph: graph,
 	orientation: 'left',
 	tickFormat: Rickshaw.Fixtures.Number.formatKMBT,
-	element: document.getElementById('y_axis'),
+	element: document.getElementById('y_axis')
 } );
 
 graph.render();


### PR DESCRIPTION
I don't believe trailing comma support was added until ES5.
