### PR TITLE
rounded number fixtures

### DIFF
--- a/src/js/Rickshaw.Fixtures.Number.js
+++ b/src/js/Rickshaw.Fixtures.Number.js
@@ -22,3 +22,29 @@ Rickshaw.Fixtures.Number.formatBase1024KMGTP = function(y) {
     else if (abs_y === 0)           { return '' }
     else                        { return y }
 };
+
+
+Rickshaw.Fixtures.Number.formatKMBT_round = function(y,a,b,precision) {
+        var abs_y = Math.abs(y);
+        if (typeof precision === "undefined"){precision = 2;}
+        if (abs_y >= 1000000000000)   { return (y / 1000000000000).toFixed(precision) + "T" }
+        else if (abs_y >= 1000000000) { return (y / 1000000000).toFixed(precision) + "B" }
+        else if (abs_y >= 1000000)    { return (y / 1000000).toFixed(precision) + "M" }
+        else if (abs_y >= 1000)       { return (y / 1000).toFixed(precision) + "K" }
+        else if (abs_y < 1 && y > 0)  { return y.toFixed(precision) }
+        else if (abs_y === 0)         { return 0 }
+        else                      { return y.toFixed(precision) }
+};
+
+Rickshaw.Fixtures.Number.formatBase1024KMGTP_round = function(y, a,b,precision) {
+    var abs_y = Math.abs(y);
+    if (typeof precision === "undefined"){precision = 2;}
+    if (abs_y >= 1125899906842624)  { return (y / 1125899906842624).toFixed(precision) + "P" }
+    else if (abs_y >= 1099511627776){ return (y / 1099511627776).toFixed(precision) + "T" }
+    else if (abs_y >= 1073741824)   { return (y / 1073741824).toFixed(precision) + "G" }
+    else if (abs_y >= 1048576)      { return (y / 1048576).toFixed(precision) + "M" }
+    else if (abs_y >= 1024)         { return (y / 1024).toFixed(precision) + "K" }
+    else if (abs_y < 1 && y > 0)    { return y.toFixed(2) }
+    else if (abs_y === 0)           { return 0 }
+    else                      { return y.toFixed(precision) }
+};


### PR DESCRIPTION
Having a number fixture is good for showing nice units on axes, but depending on the range of the axes, the precision shown throws the axis out in formatting styles. E.g having 1.66666667G looks bad on an axis. 

This change includes a new Fixture type, _round, for both base10 and base2 number fixtures. 

The excess parameter definition is a work in progress. From local commit msgs: 

>  Add precision parameter to _round fixtures in Rickshaw
> Note a,b parameters - d3 will send <val>,a,b to this function, where a is an
> incrementor(?) and b is another value. Therefore,for another parameter to be
> added, it needs to be a 4th parameter
