### PR TITLE
Guard against d3 'length' undefined error

### DIFF
--- a/src/js/Rickshaw.Graph.Renderer.Bar.js
+++ b/src/js/Rickshaw.Graph.Renderer.Bar.js
@@ -25,7 +25,7 @@ Rickshaw.Graph.Renderer.Bar = Rickshaw.Class.create( Rickshaw.Graph.Renderer, {
 
 		var domain = $super();
 
-		var frequentInterval = this._frequentInterval(this.graph.stackedData.slice(-1).shift());
+		var frequentInterval = this._frequentInterval(this.graph.stackedData.slice(-1).shift() || []);
 		domain.x[1] += Number(frequentInterval.magnitude);
 
 		return domain;
@@ -33,7 +33,7 @@ Rickshaw.Graph.Renderer.Bar = Rickshaw.Class.create( Rickshaw.Graph.Renderer, {
 
 	barWidth: function(series) {
 
-		var frequentInterval = this._frequentInterval(series.stack);
+		var frequentInterval = this._frequentInterval(series ? series.stack : []);
 		var barWidth = this.graph.x.magnitude(frequentInterval.magnitude) * (1 - this.gapSize);
 
 		return barWidth;

--- a/src/js/Rickshaw.Graph.js
+++ b/src/js/Rickshaw.Graph.js
@@ -182,7 +182,11 @@ Rickshaw.Graph = function(args) {
 
 			var layout = d3.layout.stack();
 			layout.offset( self.offset );
-			stackedData = layout(data);
+            if (data.length) {
+                stackedData = layout(data);
+            } else {
+                stackedData = [];
+            }
 		}
 
 		stackedData = stackedData || data;


### PR DESCRIPTION
Occurs when Rickshaw.Graph.render() is called with no data. Here we
simply check that scenario before calling d3. See issue #438.

This is my naive solution to the issue, however it does fix the issue in my application.
