### PR TITLE
Adding bower.json file. Fixes #361.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,36 @@
+{
+  "name": "rickshaw",
+  "main": [
+    "rickshaw.js", 
+    "rickshaw.css"
+  ],
+  "version": "1.5.0",
+  "homepage": "https://github.com/shutterstock/rickshaw",
+  "authors": [
+    "shutterstock"
+  ],
+  "description": "JavaScript toolkit for creating interactive real-time graphs",
+  "moduleType": [
+    "amd"
+  ],
+  "keywords": [
+    "d3",
+    "charts",
+    "rickshaw",
+    "svg",
+    "graph"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "tests",
+    "tutorial",
+    "examples",
+    "vendor"
+  ],
+  "dependencies": {
+    "d3": "~3.4.11"
+  }
+}


### PR DESCRIPTION
As per #361, this adds a basic bower.json file. 

Might I also suggest using Bower for dependency management in general? This would involve adding a .bowerrc file saying to use `vendor` instead of `bower_components`, and rewriting the examples to point to something like `/vendor/d3/d3.js` instead. 