### PR TITLE
Better documentation around stacked and unstacked rendering.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Line smoothing / interpolation method (see [D3 docs](https://github.com/mbostock
 
 ##### stack
 
-Boolean to specify whether series should be stacked while in the context of stacking renderers (area, bar, etc).  Defaults to true.
+Allows you to specify whether series should be stacked while in the context of stacking renderers (area, bar, etc).  Defaults to `stack: 'true'`. To unstack, `unstack: 'true'`.
 
 ### Methods
 


### PR DESCRIPTION
I wanted to make it clearer that the current implementation is `stack: 'true'` and `unstack: 'true'` instead of `stack: 'true'` and `stack: 'false'`. Took me a while of wall + head banging before I discovered this. :smile: 