### PR TITLE
Show units when displaying minutes.

### DIFF
--- a/src/js/Rickshaw.Fixtures.Time.js
+++ b/src/js/Rickshaw.Fixtures.Time.js
@@ -42,7 +42,7 @@ Rickshaw.Fixtures.Time = function() {
 		}, {
 			name: 'minute',
 			seconds: 60,
-			formatter: function(d) { return d.getUTCMinutes() }
+			formatter: function(d) { return d.getUTCMinutes() + 'm' }
 		}, {
 			name: '15 second',
 			seconds: 15,


### PR DESCRIPTION
When time is being displayed in minutes there is no indication of units.
