### PR TITLE
override which key to fetch legend swatch color from

### DIFF
--- a/src/js/Rickshaw.Graph.Legend.js
+++ b/src/js/Rickshaw.Graph.Legend.js
@@ -8,6 +8,7 @@ Rickshaw.Graph.Legend = Rickshaw.Class.create( {
 		this.element = args.element;
 		this.graph = args.graph;
 		this.naturalOrder = args.naturalOrder;
+		this.colorKey = args.colorKey || 'color';
 
 		this.element.classList.add(this.className);
 
@@ -55,7 +56,7 @@ Rickshaw.Graph.Legend = Rickshaw.Class.create( {
 		}
 		var swatch = document.createElement('div');
 		swatch.className = 'swatch';
-		swatch.style.backgroundColor = series.color;
+		swatch.style.backgroundColor = series[this.colorKey];
 
 		line.appendChild(swatch);
 
@@ -84,4 +85,3 @@ Rickshaw.Graph.Legend = Rickshaw.Class.create( {
 		return line;
 	}
 } );
-

--- a/tests/Rickshaw.Graph.Legend.js
+++ b/tests/Rickshaw.Graph.Legend.js
@@ -18,6 +18,8 @@ exports.setUp = function(callback) {
 		series: [
 			{
 				name: 'foo',
+				color: 'green',
+				stroke: 'red',
 				data: [
 					{ x: 4, y: 32 }
 				]
@@ -77,6 +79,31 @@ exports.canOverrideClassName = function(test) {
 	});
 	
 	test.equal(this.legendEl.className, "fnord")
+	test.done();
+};
+
+exports.hasDefaultColorKey = function(test) {
+	var legend = new Rickshaw.Graph.Legend({
+		graph: this.graph,
+		element: this.legendEl
+	});
+
+
+	test.equal(legend.colorKey, "color");
+	test.equal(this.legendEl.getElementsByClassName('swatch')[1].style.backgroundColor, "green");
+	test.done();
+};
+
+exports.canOverrideColorKey = function(test) {
+	var legend = new Rickshaw.Graph.Legend({
+		graph: this.graph,
+		element: this.legendEl,
+		colorKey: 'stroke'
+	});
+
+
+	test.equal(legend.colorKey, "stroke");
+	test.equal(this.legendEl.getElementsByClassName('swatch')[1].style.backgroundColor, "red");
 	test.done();
 };
 


### PR DESCRIPTION
Ability to override to to fetch the color of the legend from `stroke` rather than `color`.
