### PR TITLE
Add default value for `renderer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Array of objects containing series data to plot.  Each object should contain `da
 
 ##### renderer
 
-A string containing the name of the renderer to be used.  Options include `area`, `stack`, `bar`, `line`, and `scatterplot`.  Also see the `multi` meta renderer in order to support different renderers per series.
+A string containing the name of the renderer to be used.  Options include `area`, `stack`, `bar`, `line`, and `scatterplot`.  Defaults to `line`. Also see the `multi` meta renderer in order to support different renderers per series. 
 
 ##### width
 


### PR DESCRIPTION
As much as I understand, `renderer` defaults to `line`. Adding that in the README
