### PR TITLE
Make RangeSlider creation not depend on DOM ready event callback

### DIFF
--- a/rickshaw.js
+++ b/rickshaw.js
@@ -2434,39 +2434,37 @@ Rickshaw.Graph.RangeSlider = Rickshaw.Class.create({
 		var domain = graph.dataDomain();
 		var self = this;
 
-		$( function() {
-			$(element).slider( {
-				range: true,
-				min: domain[0],
-				max: domain[1],
-				values: [ 
-					domain[0],
-					domain[1]
-				],
-				slide: function( event, ui ) {
+		$(element).slider( {
+			range: true,
+			min: domain[0],
+			max: domain[1],
+			values: [ 
+				domain[0],
+				domain[1]
+			],
+			slide: function( event, ui ) {
 
-					if (ui.values[1] <= ui.values[0]) return;
+				if (ui.values[1] <= ui.values[0]) return;
 
-					graph.window.xMin = ui.values[0];
-					graph.window.xMax = ui.values[1];
-					graph.update();
+				graph.window.xMin = ui.values[0];
+				graph.window.xMax = ui.values[1];
+				graph.update();
 
-					var domain = graph.dataDomain();
+				var domain = graph.dataDomain();
 
-					// if we're at an extreme, stick there
-					if (domain[0] == ui.values[0]) {
-						graph.window.xMin = undefined;
-					}
-
-					if (domain[1] == ui.values[1]) {
-						graph.window.xMax = undefined;
-					}
-
-					self.slideCallbacks.forEach(function(callback) {
-						callback(graph, graph.window.xMin, graph.window.xMax);
-					});
+				// if we're at an extreme, stick there
+				if (domain[0] == ui.values[0]) {
+					graph.window.xMin = undefined;
 				}
-			} );
+
+				if (domain[1] == ui.values[1]) {
+					graph.window.xMax = undefined;
+				}
+
+				self.slideCallbacks.forEach(function(callback) {
+					callback(graph, graph.window.xMin, graph.window.xMax);
+				});
+			}
 		} );
 
 		$(element)[0].style.width = graph.width + 'px';


### PR DESCRIPTION
Make RangeSlider creation not depend on DOM ready event callback (Issue #499)
