### PR TITLE
Add homepage, repository and issues links in package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,16 @@
 {
   "name": "rickshaw",
   "version": "1.4.6",
+  "homepage": "http://code.shutterstock.com/rickshaw/",
   "dependencies": {
     "d3": "~3.3.6"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/shutterstock/rickshaw.git"
+  },
+  "bugs": {
+    "url": "https://github.com/shutterstock/rickshaw/issues"
   },
   "keywords": [
     "d3",


### PR DESCRIPTION
Hello there, and thanks for a fantastic library.

This is just a minor PR to add some more metadata to package.json. This is beneficial when you browse for the package on npmjs.org, but it also fixes the following warning when installing rickshaw through npm:

```
npm WARN package.json rickshaw@1.4.6 No repository field.
```

Also, just as a side note. It would be awesome if you published a new version to npm as well (ref #488)

Thanks again for making this available and have a great day!
