### PR TITLE
fixing local time ticks

### DIFF
--- a/src/js/Rickshaw.Fixtures.Time.Local.js
+++ b/src/js/Rickshaw.Fixtures.Time.Local.js
@@ -76,7 +76,7 @@ Rickshaw.Fixtures.Time.Local = function() {
 
 	this.ceil = function(time, unit) {
 
-		var date, floor, year;
+		var date, floor, year, offset;
 
 		if (unit.name == 'day') {
 
@@ -125,7 +125,7 @@ Rickshaw.Fixtures.Time.Local = function() {
 
 			return new Date(year, 0).getTime() / 1000;
 		}
-
-		return Math.ceil(time / unit.seconds) * unit.seconds;
+		offset = new Date(time * 1000).getTimezoneOffset() * 60;
+		return Math.ceil((time - offset) / unit.seconds) * unit.seconds + offset;
 	};
 };


### PR DESCRIPTION
In timezone other than GMT, for Rickshaw.Graph.Axis.Time using Rickshaw.Fixtures.Time.Local as timeFixture ticks are applied as per GMT. This commit fixes it.

Consider following,
In timezone IST (GMT-0530), for x-axis domain [1420741800, 1420828200) i. e. [Fri Jan 09 2015 00:00:00 GMT+0530 (IST), Sat Jan 10 2015 00:00:00 GMT+0530 (IST)) with ticks every 6 hours, expected ticks must be at (00:00, 06:00, 12:00, 18:00) or [1420741800, 1420763400, 1420785000, 1420806600] in unix timestamps.

Without this fix, ticks were generated at (05:30, 11:30, 17:30, 23:30) or [1420761600, 1420783200, 1420804800, 1420826400].

This will fix things for everyone trying to display graphs with time x-axis ticks as per local time.

Bug also reported at #504 