### PR TITLE
Fix typo

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -148,7 +148,7 @@ img {
 	<div>
 		<h2><a href="ajax.html">Data via AJAX / JSONP</a></h2>
 		<span>
-			Ask Rickshaw to fetch data via AJAX, rather than specifying in the constructor.  There's a JSONP impelementation too.
+			Ask Rickshaw to fetch data via AJAX, rather than specifying in the constructor.  There's a JSONP implementation too.
 		</span>
 	</div>
 </section>


### PR DESCRIPTION
Fix typo in `examples/index.html`