### PR TITLE
Make calculating interval in bar chart consistent. Fixes #461

### DIFF
--- a/src/js/Rickshaw.Graph.Renderer.Bar.js
+++ b/src/js/Rickshaw.Graph.Renderer.Bar.js
@@ -96,8 +96,13 @@ Rickshaw.Graph.Renderer.Bar = Rickshaw.Class.create( Rickshaw.Graph.Renderer, {
 		}
 
 		var frequentInterval = { count: 0, magnitude: 1 };
-
-		Rickshaw.keys(intervalCounts).forEach( function(i) {
+		
+		// Sorting object's keys returned to guarantee consistency when iterating over
+		// Keys order in `for .. in` loop is not specified and browsers behave differently here
+		// This results with different invterval value being calculated for different browsers
+		// See last but one section here: http://www.ecma-international.org/ecma-262/5.1/#sec-12.6.4
+		var keysSorted = Rickshaw.keys(intervalCounts).sort(function asc(a, b) { return Number(a) - Number(b); });
+		keysSorted.forEach( function(i) {
 			if (frequentInterval.count < intervalCounts[i]) {
 				frequentInterval = {
 					count: intervalCounts[i],


### PR DESCRIPTION
For some cases bar charts are incorrectly rendered in Firefox, see #461 as an example. Bar width indirectly depends on `_frequentInterval` function that in turn creates an object and then iterates over its properties. Turns out that order of keys returned (as in `for..in` loop) is inconsistent between browsers and this leads to taking different values in different browsers. This PR unifies how keys are traversed - keys collection is sorted first before iterating over.

For details see last but one section here: http://www.ecma-international.org/ecma-262/5.1/#sec-12.6.4.