### PR TITLE
HoverDetail should default to being inactive.

### DIFF
--- a/src/js/Rickshaw.Graph.HoverDetail.js
+++ b/src/js/Rickshaw.Graph.HoverDetail.js
@@ -15,7 +15,7 @@ Rickshaw.Graph.HoverDetail = Rickshaw.Class.create({
 		};
 
 		var element = this.element = document.createElement('div');
-		element.className = 'detail';
+		element.className = 'detail inactive';
 
 		this.visible = true;
 		graph.element.appendChild(element);


### PR DESCRIPTION
Currently, when you first load a page with a graph that has HoverDetail enabled, you'll see a line on the right side of your chart. Here it is in the demo (grey line on the left side):

![screen shot 2015-02-23 at 1 24 06 am](https://cloud.githubusercontent.com/assets/928757/6325343/4895c682-bafb-11e4-92d6-08c20a56cad3.png)

This PR defaults the HoverDetail to be inactive, so the grey line doesn't show until the user interacts with the chart:

![screen shot 2015-02-23 at 1 23 53 am](https://cloud.githubusercontent.com/assets/928757/6325348/69b2c0c2-bafb-11e4-8287-c58d8d058256.png)
