### PR TITLE
Add Rickshaw.Graph.Dragzoom

### DIFF
--- a/src/js/Rickshaw.Graph.DragZoom.js
+++ b/src/js/Rickshaw.Graph.DragZoom.js
@@ -1,0 +1,119 @@
+Rickshaw.namespace('Rickshaw.Graph.DragZoom');
+
+Rickshaw.Graph.DragZoom = Rickshaw.Class.create({
+
+	initialize: function(args) {
+		if (!args.graph) {
+			throw "Rickshaw.Graph.DragZoom needs a reference to a graph";
+		}
+		var defaults = {
+			opacity: 0.5,
+			fill: 'steelblue',
+			minimumTimeSelection: 60,
+			callback: function() {}
+		};
+
+		this.graph = args.graph;
+		this.svg = d3.select(this.graph.element).select("svg");
+		this.svgWidth = parseInt(this.svg.attr("width"), 10);
+		this.opacity = args.opacity || defaults.opacity;
+		this.fill = args.fill || defaults.fill;
+		this.minimumTimeSelection = args.minimumTimeSelection || defaults.minimumTimeSelection;
+		this.callback = args.callback || defaults.callback;
+
+		this.registerMouseEvents();
+	},
+
+	registerMouseEvents: function() {
+		var self = this;
+		var ESCAPE_KEYCODE = 27;
+		var rectangle;
+
+		var drag = {
+			startDt: null,
+			stopDt: null,
+			startPX: null,
+			stopPX: null
+		};
+
+		this.svg.on("mousedown", onMousedown);
+
+		function onMouseup(datum, index) {
+			drag.stopDt = pointAsDate(d3.event);
+			var windowAfterDrag = [
+				drag.startDt,
+				drag.stopDt
+			].sort(compareNumbers);
+
+			self.graph.window.xMin = windowAfterDrag[0];
+			self.graph.window.xMax = windowAfterDrag[1];
+
+			var endTime = self.graph.window.xMax;
+			var range = self.graph.window.xMax - self.graph.window.xMin;
+
+			reset(this);
+
+			if (range < self.minimumTimeSelection || isNaN(range)) {
+				return;
+			}
+			self.graph.update();
+			self.callback({range: range, endTime: endTime});
+		}
+
+		function onMousemove() {
+			var offset = drag.stopPX = (d3.event.offsetX || d3.event.layerX);
+			if (offset > (self.svgWidth - 1) || offset < 1) {
+				return;
+			}
+
+			var limits = [drag.startPX, offset].sort(compareNumbers);
+			var selectionWidth = limits[1]-limits[0];
+			if (isNaN(selectionWidth)) {
+				return reset(this);
+			}
+			rectangle.attr("fill", self.fill)
+			.attr("x", limits[0])
+			.attr("width", selectionWidth);
+		}
+
+		function onMousedown() {
+			var el = d3.select(this);
+			rectangle = el.append("rect")
+			.style("opacity", self.opacity)
+			.attr("y", 0)
+			.attr("height", "100%");
+
+			if(d3.event.preventDefault) {
+				d3.event.preventDefault();
+			} else {
+				d3.event.returnValue = false;
+			}
+			drag.target = d3.event.target;
+			drag.startDt = pointAsDate(d3.event);
+			drag.startPX = d3.event.offsetX || d3.event.layerX;
+			el.on("mousemove", onMousemove);
+			d3.select(document).on("mouseup", onMouseup);
+			d3.select(document).on("keyup", function() {
+				if (d3.event.keyCode === ESCAPE_KEYCODE) {
+					reset(this);
+				}
+			});
+		}
+
+		function reset(el) {
+			var s = d3.select(el);
+			s.on("mousemove", null);
+			d3.select(document).on("mouseup", null);
+			drag = {};
+			rectangle.remove();
+		}
+
+		function compareNumbers(a, b) {
+			return a - b;
+		}
+
+		function pointAsDate(e) {
+			return Math.floor(self.graph.x.invert(e.offsetX || e.layerX));
+		}
+	}
+});

--- a/tests/Rickshaw.Graph.DragZoom.js
+++ b/tests/Rickshaw.Graph.DragZoom.js
@@ -1,0 +1,56 @@
+exports.setUp = function(callback) {
+
+	Rickshaw = require('../rickshaw');
+
+	global.document = d3.select('html')[0][0].parentNode;
+	global.window = document.defaultView;
+
+	new Rickshaw.Compat.ClassList();
+
+	callback();
+};
+
+exports.tearDown = function(callback) {
+
+	delete require.cache.d3;
+	callback();
+};
+
+exports.basic = function(test) {
+
+	var el = document.createElement("div");
+
+	var graph = new Rickshaw.Graph({
+		element  : el,
+		width    : 960,
+		height   : 500,
+		renderer : 'scatterplot',
+		series   : [{
+			color : 'steelblue',
+			data  : [
+				{ x: 0, y: 40 },
+				{ x: 1, y: 49 },
+				{ x: 2, y: 38 },
+				{ x: 3, y: 30 },
+				{ x: 4, y: 32 } ]
+		}]
+	} );
+
+	graph.renderer.dotSize = 6;
+	graph.render();
+
+	var drag = new Rickshaw.Graph.DragZoom({
+		graph: graph,
+		opacity: 0.5,
+		fill: 'steelblue',
+		minimumTimeSelection: 15,
+		callback: function(args) {
+			console.log(args.range, args.endTime);
+		}
+	});
+
+	test.equal(graph.renderer.name, drag.graph.renderer.name);
+	test.done();
+};
+
+


### PR DESCRIPTION
Clicking and dragging on a graph will highlight a selection area. Mouseup re-renders the graph with the selected range, `esc` cancels the selection.
