### PR TITLE
RangeSlider: Resize when original graph changes width

### DIFF
--- a/src/js/Rickshaw.Graph.RangeSlider.js
+++ b/src/js/Rickshaw.Graph.RangeSlider.js
@@ -58,8 +58,13 @@ Rickshaw.Graph.RangeSlider = Rickshaw.Class.create({
 			} );
 		} );
 
-		$(element)[0].style.width = graph.width + 'px';
+		graph.onConfigure(this.configure.bind(this));
+		this.configure();
 
+	},
+
+	configure: function() {
+		this.element.style.width = this.graph.width + 'px';
 	},
 
 	update: function() {


### PR DESCRIPTION
This feature is already available for the preview rangeslider (minimap), but the regular range slider does not resize. This fixes that (if resized through configure, same as the other).
