### PR TITLE
bower ready, with d3 dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,26 @@
+{
+  "name": "rickshaw",
+  "description": "Rickshaw is a JavaScript toolkit for creating interactive time series graphs.",
+  "main": "./rickshaw",
+  "license": "MIT",
+  "keywords": [
+    "d3",
+    "charts",
+    "rickshaw",
+    "svg",
+    "graph"
+  ],
+  "homepage": "https://github.com/shutterstock/rickshaw",
+  "moduleType": [],
+  "ignore": [
+    "**/.*",
+    "bower_components",
+    "examples",
+    "node_modules",
+    "tests",
+    "turorial"
+  ],
+  "dependencies": {
+    "d3": "~3.5.5"
+  }
+}


### PR DESCRIPTION
This solve problem with d3 dependency when rickshaw is installed via bower. Specifically when installed angular-rickshaw, because bower can't resolve dependencies.

Problem:
```
Uncaught ReferenceError: d3 is not defined
```