### PR TITLE
Correct check for undefined variable

### DIFF
--- a/src/js/Rickshaw.Graph.js
+++ b/src/js/Rickshaw.Graph.js
@@ -304,7 +304,7 @@ Rickshaw.Graph = function(args) {
 
 		args = args || {};
 
-		if (typeof window !== undefined) {
+		if (typeof window !== 'undefined') {
 			var style = window.getComputedStyle(this.element, null);
 			var elementWidth = parseInt(style.getPropertyValue('width'), 10);
 			var elementHeight = parseInt(style.getPropertyValue('height'), 10);


### PR DESCRIPTION
The code was comparing the result of `typeof` with a variable named `undefined`.

As typeof returns a string it should compare to `'undefined'`