### PR TITLE
Added possibility to add a colored min/max area for a series

### DIFF
--- a/src/js/Rickshaw.Graph.Behavior.Series.Highlight.js
+++ b/src/js/Rickshaw.Graph.Behavior.Series.Highlight.js
@@ -8,10 +8,12 @@ Rickshaw.Graph.Behavior.Series.Highlight = function(args) {
 	var self = this;
 
 	var colorSafe = {};
+	var limitColorSafe = {};
 	var activeLine = null;
 
-	var disabledColor = args.disabledColor || function(seriesColor) {
-		return d3.interpolateRgb(seriesColor, d3.rgb('#d8d8d8'))(0.8).toString();
+	var disabledColor = args.disabledColor || function(seriesColor, interpolateColor) {
+		interpolateColor = interpolateColor === undefined ? '#d8d8d8' : interpolateColor;
+		return d3.interpolateRgb(seriesColor, d3.rgb(interpolateColor))(0.8).toString();
 	};
 
 	this.addHighlightEvents = function (l) {
@@ -39,6 +41,8 @@ Rickshaw.Graph.Behavior.Series.Highlight = function(args) {
 
 				colorSafe[line.series.name] = colorSafe[line.series.name] || line.series.color;
 				line.series.color = disabledColor(line.series.color);
+				limitColorSafe[line.series.name] = limitColorSafe[line.series.name] || line.series.limitColor;
+				line.series.limitColor = disabledColor(line.series.limitColor, "#FFFFFF");
 
 			} );
 
@@ -63,6 +67,7 @@ Rickshaw.Graph.Behavior.Series.Highlight = function(args) {
 
 				if (colorSafe[line.series.name]) {
 					line.series.color = colorSafe[line.series.name];
+					line.series.limitColor = limitColorSafe[line.series.name];
 				}
 			} );
 

--- a/src/js/Rickshaw.Graph.Renderer.js
+++ b/src/js/Rickshaw.Graph.Renderer.js
@@ -90,6 +90,26 @@ Rickshaw.Graph.Renderer = Rickshaw.Class.create( {
 			.filter(function(s) { return !s.disabled })
 			.map(function(s) { return s.stack });
 
+		series.forEach(function(series){
+			if(series.disabled || series.min === undefined || series.max === undefined)
+				return;
+
+			var min = series.min;
+			var max = series.max;
+
+			if(min >= max)
+				return;
+
+			var color = series.limitColor === undefined ? d3.interpolateRgb(d3.rgb(series.color), d3.rgb('#FFFFFF'))(0.7).toString() : series.limitColor;
+
+			vis.append("rect")
+				.attr("x", 0)
+				.attr("y", graph.y(max))                        //upper limit
+				.attr("height", graph.y(min) - graph.y(max))    //lower limit
+				.attr("width", graph.width)
+				.style("fill", color)
+		});
+
 		var pathNodes = vis.selectAll("path.path")
 			.data(data)
 			.enter().append("svg:path")
@@ -179,4 +199,3 @@ Rickshaw.Graph.Renderer = Rickshaw.Class.create( {
 		}
 	}
 } );
-


### PR DESCRIPTION
This change allows to add min/max values to a series. The renderer takes the series color as default color an modifies it a bit, alternatively a custom color can be passed.

```javascript
var graph = new Rickshaw.Graph( {
	element: document.querySelector('#chart'),
	renderer: 'line',
	series: [{
		color: 'steelblue',
		data: [ { x: 0, y: 23}, { x: 1, y: 15 }, { x: 2, y: 79 }, { x: 3, y: 40 } ],
		min: 20,
		max: 50,
		limitColor: "#FF6766" 
		}]
	});

graph.render();
```

Produces this output: 
![simple](https://cloud.githubusercontent.com/assets/22519008/22924389/33afa1a0-f2a5-11e6-8f20-39a9bea775a9.png)


More complex example:
![not simple](https://cloud.githubusercontent.com/assets/22519008/22924545/c3d30a1a-f2a5-11e6-822f-4a389acefc2c.png)

