### PR TITLE
fixed stacked area chart hover detail bug in firefox

### DIFF
--- a/src/js/Rickshaw.Graph.HoverDetail.js
+++ b/src/js/Rickshaw.Graph.HoverDetail.js
@@ -45,8 +45,8 @@ Rickshaw.Graph.HoverDetail = Rickshaw.Class.create({
 
 		var graph = this.graph;
 
-		var eventX = e.offsetX || e.layerX;
-		var eventY = e.offsetY || e.layerY;
+		var eventX = e.layerX || e.offsetX;
+		var eventY = e.layerY || e.offsetY;
 
 		var j = 0;
 		var points = [];


### PR DESCRIPTION
**Hover Detail** would only appear for the _top-most series_ in _area-charts_ ([open examples/extensions.html in Firefox](http://code.shutterstock.com/rickshaw/examples/extensions.html)). Tested in Firefox and Chrome, on a Linux Machine.