### PR TITLE
Create a locally scoped copy of the loop-index var to prevent accessing an out-of-bound index in the onConfigure callback

### DIFF
--- a/src/js/Rickshaw.Graph.RangeSlider.js
+++ b/src/js/Rickshaw.Graph.RangeSlider.js
@@ -21,12 +21,17 @@ Rickshaw.Graph.RangeSlider = Rickshaw.Class.create({
 		this.build();
 
 		for (var i = 0; i < graphs.length; i++) {
+			// When the loop exits, the value of i would be an out-of-bound index for the 
+			// graphs array, which would cause problems when it's used in the onConfigure
+			// callback below. Since there are no block scopes in JS. Hence, a locally scoped 
+			// copy.
+			var idx = i;
 			graphs[i].onUpdate(function() {
 				self.update();
 			}.bind(self));
 
 			graphs[i].onConfigure(function() {
-				$(element)[0].style.width = graphs[i].width + 'px';
+				$(element)[0].style.width = graphs[idx].width + 'px';
 			}.bind(self));
 		}
 


### PR DESCRIPTION
I am not sure what the code-of-conduct was here. I spotted a problem while working on something and thought that a quick PR might be helpful.

Since JS doesn't have block scope, the value of the loop-index var `i` would be equal to the length of the `graphs` array when the loop exits. This incorrect value of `i` would be used from the `onConfigure` callback and will result in an exception. This PR helps prevent that.


