### PR TITLE
Create a locally scoped copy of the loop-index var to prevent incorrect index in the onConfigure callback

### DIFF
--- a/src/js/Rickshaw.Graph.RangeSlider.js
+++ b/src/js/Rickshaw.Graph.RangeSlider.js
@@ -21,18 +21,20 @@ Rickshaw.Graph.RangeSlider = Rickshaw.Class.create({
 		this.build();
 
 		for (var i = 0; i < graphs.length; i++) {
-			// When the loop exits, the value of i would be an out-of-bound index for the 
-			// graphs array, which would cause problems when it's used in the onConfigure
-			// callback below. Since there are no block scopes in JS. Hence, a locally scoped 
-			// copy.
-			var idx = i;
 			graphs[i].onUpdate(function() {
 				self.update();
 			}.bind(self));
 
-			graphs[i].onConfigure(function() {
-				$(element)[0].style.width = graphs[idx].width + 'px';
-			}.bind(self));
+			(function() {
+				// When the loop exits, the value of i would be an out-of-bound index for the
+				// graphs array, which would cause problems when it's used in the onConfigure
+				// callback below. Since there are no block scopes in JS. Hence, a locally scoped
+				// copy.
+				var idx = i;
+				graphs[i].onConfigure(function() {
+					$(element)[0].style.width = graphs[idx].width + 'px';
+				}.bind(self));
+			})();
 		}
 
 	},


### PR DESCRIPTION
This is a follow-up on the PR #568. I made that one too quickly, without realizing that I still hadn't solved the problem. That is, no local scope was being created. 

I also checked how the `onConfigure` callbacks were being used, and it turns out that using `this` won't work from inside the callbacks. So using an `IIFE` to capture a local value. Since JS doesn't have block scopes, only function scopes. So, in order to capture a loop-index variable for 
the later `onConfigure` function callback, we create an IIFE. Which creates a local variable.