### PR TITLE
Test dragzoom

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ JS_FILES=\
 	src/js/Rickshaw.Graph.Behavior.Series.Highlight.js\
 	src/js/Rickshaw.Graph.Behavior.Series.Order.js\
 	src/js/Rickshaw.Graph.Behavior.Series.Toggle.js\
+	src/js/Rickshaw.Graph.DragZoom.js\
 	src/js/Rickshaw.Graph.HoverDetail.js\
 	src/js/Rickshaw.Graph.JSONP.js\
 	src/js/Rickshaw.Graph.Legend.js\

--- a/examples/drag_zoom.html
+++ b/examples/drag_zoom.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <link type="text/css" rel="stylesheet" href="../rickshaw.css">
+  <script src="../vendor/d3.v3.js"></script>
+  <script src="../rickshaw.js"></script>
+</head>
+<body>
+  <div id="chart"></div>
+
+  <script>
+
+  // set up our data series with 50 random data points
+  var seriesData = [
+    [],
+    [],
+    []
+  ];
+  var random = new Rickshaw.Fixtures.RandomData(150);
+
+  for (var i = 0; i < 500; i++) {
+    random.addData(seriesData);
+    seriesData[0][i].r = 0 | Math.random() * 2 + 8
+    seriesData[1][i].r = 0 | Math.random() * 5 + 5
+    seriesData[2][i].r = 0 | Math.random() * 8 + 2
+  }
+
+  // instantiate our graph!
+
+  var graph = new Rickshaw.Graph({
+    element: document.getElementById("chart"),
+    width: 960,
+    height: 500,
+    renderer: 'scatterplot',
+    series: [{
+      color: "#ff9030",
+      data: seriesData[0],
+      opacity: 0.5
+    }, {
+      color: "#ff4040",
+      data: seriesData[1],
+      opacity: 0.3
+    }, {
+      color: "#4040ff",
+      data: seriesData[2]
+    }]
+  });
+
+  graph.renderer.dotSize = 6;
+
+  new Rickshaw.Graph.HoverDetail({
+    graph: graph
+  });
+
+  var drag = new Rickshaw.Graph.DragZoom({
+    graph: graph,
+    opacity: 0.5,
+    fill: 'steelblue',
+    minimumTimeSelection: 15,
+    callback: function(args) {
+      console.log(args.range, args.endTime);
+    }
+  });
+
+  graph.render();
+
+
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "build": "make clean && make",
     "examples": "open examples/index.html",
     "lint": "jshint src/js/*",
-    "test": "nodeunit tests",
+    "test": "make && nodeunit tests",
     "watch": "nodemon --watch src --exec make rickshaw.js",
     "coverage": "istanbul cover nodeunit tests --reporter=lcov",
     "coveralls": "cat ./coverage/lcov.info | coveralls"

--- a/src/js/Rickshaw.Graph.DragZoom.js
+++ b/src/js/Rickshaw.Graph.DragZoom.js
@@ -3,8 +3,8 @@ Rickshaw.namespace('Rickshaw.Graph.DragZoom');
 Rickshaw.Graph.DragZoom = Rickshaw.Class.create({
 
 	initialize: function(args) {
-		if (!args.graph) {
-			throw "Rickshaw.Graph.DragZoom needs a reference to a graph";
+		if (!args || !args.graph) {
+			throw new Error("Rickshaw.Graph.DragZoom needs a reference to a graph");
 		}
 		var defaults = {
 			opacity: 0.5,

--- a/tests/Rickshaw.Graph.DragZoom.js
+++ b/tests/Rickshaw.Graph.DragZoom.js
@@ -81,7 +81,7 @@ exports.drag = function(test) {
 	event.initMouseEvent('mousemove', true, true, window, 1, 900, 600, 290, 260, false, false, false, false, 0, null);
 	drag.svg[0][0].dispatchEvent(event);
 
-	// TODO bug or problem with d3.event when run with jsdom?
+	// TODO offsetX is not currently set on d3.event in d3 v3 when run with jsdom
 	test.equal(rect.attributes.fill, null);
 	test.equal(rect.attributes.x, null);
 	test.equal(rect.attributes.width, null);
@@ -163,7 +163,7 @@ exports.notDrag = function(test) {
 	rect = d3.select(element).selectAll('rect')[0][0];
 	test.equal(rect, null, 'after mouseup rect is gone');
 
-	// TODO bug? registerMouseEvents is only called in initialize, not in reset?
+	// This is not reproduceable in the browser
 	event = global.document.createEvent('MouseEvent');
 	event.initMouseEvent('mousedown', true, true, window, 1, 800, 600, 290, 260, false, false, false, false, 0, null);
 	drag.svg[0][0].dispatchEvent(event);

--- a/tests/Rickshaw.Graph.DragZoom.js
+++ b/tests/Rickshaw.Graph.DragZoom.js
@@ -19,25 +19,35 @@ exports.tearDown = function(callback) {
 	callback();
 };
 
-exports.basic = function(test) {
+exports.drag = function(test) {
 
-	var el = document.createElement("div");
+	var element = document.createElement("div");
 
 	var graph = new Rickshaw.Graph({
-		element  : el,
-		width    : 960,
-		height   : 500,
-		renderer : 'scatterplot',
-		series   : [{
-			color : 'steelblue',
-			data  : [
-				{ x: 0, y: 40 },
-				{ x: 1, y: 49 },
-				{ x: 2, y: 38 },
-				{ x: 3, y: 30 },
-				{ x: 4, y: 32 } ]
+		element: element,
+		width: 960,
+		height: 500,
+		renderer: 'scatterplot',
+		series: [{
+			color: 'steelblue',
+			data: [{
+				x: 0,
+				y: 40
+			}, {
+				x: 1,
+				y: 49
+			}, {
+				x: 2,
+				y: 38
+			}, {
+				x: 3,
+				y: 30
+			}, {
+				x: 4,
+				y: 32
+			}]
 		}]
-	} );
+	});
 
 	graph.renderer.dotSize = 6;
 	graph.render();
@@ -53,6 +63,112 @@ exports.basic = function(test) {
 	});
 
 	test.equal(graph.renderer.name, drag.graph.renderer.name);
+	test.equal(drag.svgWidth, 960);
+
+	var rect = d3.select(element).selectAll('rect')[0][0];
+	test.equal(rect, undefined, 'we dont have a rect for drawing drag zoom');
+
+	var event = global.document.createEvent('MouseEvent');
+	event.initMouseEvent('mousedown', true, true, window, 1, 800, 600, 290, 260, false, false, false, false, 0, null);
+	test.equal(event.screenX, 800, 'jsdom initMouseEvent works');
+	drag.svg[0][0].dispatchEvent(event);
+
+	rect = d3.select(element).selectAll('rect')[0][0];
+	test.ok(rect, 'after mousedown we have a rect for drawing drag zoom');
+	test.equal(rect.style.opacity, drag.opacity);
+
+	event = global.document.createEvent('MouseEvent');
+	event.initMouseEvent('mousemove', true, true, window, 1, 900, 600, 290, 260, false, false, false, false, 0, null);
+	drag.svg[0][0].dispatchEvent(event);
+
+	// TODO bug or problem with d3.event when run with jsdom?
+	test.equal(rect.attributes.fill, null);
+	test.equal(rect.attributes.x, null);
+	test.equal(rect.attributes.width, null);
+
+	event = global.document.createEvent('KeyboardEvent');
+	event.initEvent('keyup', true, true, null, false, false, false, false, 12, 0);
+	global.document.dispatchEvent(event);
+
+	var ESCAPE_KEYCODE = 27;
+	event = global.document.createEvent('KeyboardEvent');
+	event.initEvent('keyup', true, true, null, false, false, false, false, ESCAPE_KEYCODE, 0);
+	global.document.dispatchEvent(event);
+
+	test.done();
+};
+
+exports.notDrag = function(test) {
+
+	var element = document.createElement("div");
+
+	var graph = new Rickshaw.Graph({
+		element: element,
+		width: 960,
+		height: 500,
+		renderer: 'scatterplot',
+		series: [{
+			color: 'steelblue',
+			data: [{
+				x: 0,
+				y: 40
+			}, {
+				x: 1,
+				y: 49
+			}, {
+				x: 2,
+				y: 38
+			}, {
+				x: 3,
+				y: 30
+			}, {
+				x: 4,
+				y: 32
+			}]
+		}]
+	});
+
+	graph.renderer.dotSize = 6;
+	graph.render();
+
+	var drag = new Rickshaw.Graph.DragZoom({
+		graph: graph,
+		opacity: 0.5,
+		fill: 'steelblue',
+		minimumTimeSelection: 15,
+		callback: function(args) {
+			console.log(args.range, args.endTime);
+		}
+	});
+
+	test.equal(graph.renderer.name, drag.graph.renderer.name);
+	test.equal(drag.svgWidth, 960);
+
+	var rect = d3.select(element).selectAll('rect')[0][0];
+	test.equal(rect, undefined, 'we dont have a rect for drawing drag zoom');
+
+	var event = global.document.createEvent('MouseEvent');
+	event.initMouseEvent('mousedown', true, true, window, 1, 800, 600, 290, 260, false, false, false, false, 0, null);
+	test.equal(event.screenX, 800, 'jsdom initMouseEvent works');
+	drag.svg[0][0].dispatchEvent(event);
+
+	rect = d3.select(element).selectAll('rect')[0][0];
+	test.ok(rect, 'after mousedown we have a rect for drawing drag zoom');
+	test.equal(rect.style.opacity, drag.opacity);
+
+	event = global.document.createEvent('MouseEvent');
+	event.initMouseEvent('mouseup', true, true, window, 1, 900, 600, 290, 260, false, false, false, false, 0, null);
+	global.document.dispatchEvent(event);
+
+	rect = d3.select(element).selectAll('rect')[0][0];
+	test.equal(rect, null, 'after mouseup rect is gone');
+
+	// TODO bug? registerMouseEvents is only called in initialize, not in reset?
+	event = global.document.createEvent('MouseEvent');
+	event.initMouseEvent('mousedown', true, true, window, 1, 800, 600, 290, 260, false, false, false, false, 0, null);
+	drag.svg[0][0].dispatchEvent(event);
+	test.equal(rect, null, 'after mouseup mousedown listener is gone');
+
 	test.done();
 };
 
@@ -68,5 +184,3 @@ exports.initialize = function(test) {
 
 	test.done();
 };
-
-

--- a/tests/Rickshaw.Graph.DragZoom.js
+++ b/tests/Rickshaw.Graph.DragZoom.js
@@ -1,8 +1,11 @@
+var d3 = require("d3");
+var Rickshaw;
+
 exports.setUp = function(callback) {
 
 	Rickshaw = require('../rickshaw');
 
-	global.document = d3.select('html')[0][0].parentNode;
+	global.document = require("jsdom").jsdom("<html><head></head><body></body></html>");
 	global.window = document.defaultView;
 
 	new Rickshaw.Compat.ClassList();
@@ -50,6 +53,19 @@ exports.basic = function(test) {
 	});
 
 	test.equal(graph.renderer.name, drag.graph.renderer.name);
+	test.done();
+};
+
+exports.initialize = function(test) {
+
+	var el = document.createElement("div");
+
+	try {
+		var drag = new Rickshaw.Graph.DragZoom();
+	} catch (err) {
+		test.equal(err.message, "Rickshaw.Graph.DragZoom needs a reference to a graph");
+	}
+
 	test.done();
 };
 


### PR DESCRIPTION
@nrlakin i pulled down the drag zoom pr #512 it looks like it was just a question of updating the test to use jsdom etc. 

for an example we found prometheus was using the DragZoom code for a while https://github.com/prometheus-junkyard/promdash/blob/81a9cf2308c9daa80be9464709dd40555d774fa3/app/assets/javascripts/angular/directives/graph_chart.js