### PR TITLE
Add ToC, Install section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,41 @@
 
 Rickshaw is a JavaScript toolkit for creating interactive time series graphs, developed at [Shutterstock](http://www.shutterstock.com)
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+## Table of Contents
+
+- [Getting Started](#getting-started)
+- [Install](#install)
+  - [Dependencies](#dependencies)
+- [Rickshaw.Graph](#rickshawgraph)
+      - [element](#element)
+      - [series](#series)
+      - [renderer](#renderer)
+      - [width](#width)
+      - [height](#height)
+      - [min](#min)
+      - [max](#max)
+      - [padding](#padding)
+      - [interpolation](#interpolation)
+      - [stack](#stack)
+  - [Methods](#methods)
+      - [render()](#render)
+      - [configure()](#configure)
+      - [onUpdate(f)](#onupdatef)
+- [Extensions](#extensions)
+- [Rickshaw.Color.Palette](#rickshawcolorpalette)
+    - [Color Schemes](#color-schemes)
+    - [Interpolation](#interpolation)
+- [Rickshaw and Cross-Browser Support](#rickshaw-and-cross-browser-support)
+- [Building](#building)
+- [Contributing](#contributing)
+- [Authors](#authors)
+- [License](#license)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+
 ## Getting Started
 
 Getting started with a simple graph is straightforward.  Here's the gist:
@@ -28,7 +63,28 @@ graph.render();
 ```
 See the [overview](http://code.shutterstock.com/rickshaw/), [tutorial](http://shutterstock.github.com/rickshaw/tutorial/introduction.html), and [examples](http://shutterstock.github.com/rickshaw/examples/) for more.
 
-## Rickshaw.Graph 
+## Install
+
+In the browser, manually add `rickshaw.min.js` and `rickshaw.min.css` in the document head.
+
+Alternatively, you can install Rickshaw using [Bower](https://bower.io/) or [npm](https://npmjs.com).
+
+```sh
+# With bower
+bower install rickshaw
+# With npm
+npm install --save rickshaw
+```
+
+### Dependencies
+
+Rickshaw relies on the fantastic [D3 visualization library](http://mbostock.github.com/d3/) to do lots of the heavy lifting for stacking and rendering to SVG.
+
+Some extensions require [jQuery](http://jquery.com) and [jQuery UI](http://jqueryui.com), but for drawing some basic graphs you'll be okay without.
+
+Rickshaw uses [jsdom](https://github.com/tmpvar/jsdom) to run unit tests in Node to be able to do SVG manipulation. As of the jsdom 7.0.0 release, jsdom requires Node.js 4 or newer [jsdom changelog](https://github.com/tmpvar/jsdom/blob/master/Changelog.md#700). If you want to run the tests on your machine, and you don't have access to a version of node >= 4.0, you can `npm install jsdom@3`  so that you can run the tests using the [3.x branch of jsdom](https://github.com/tmpvar/jsdom/tree/3.x).
+
+## Rickshaw.Graph
 
 A Rickshaw graph.  Send an `element` reference, `series` data, and optionally other properties to the constructor before calling `render()` to point the graph.  A listing of properties follows.  Send these as arguments to the constructor, and optionally set them later on already-instantiated graphs with a call to `configure()`
 
@@ -164,15 +220,6 @@ For graphs with more series than palettes have colors, specify an `interpolatedS
 This library works in modern browsers and Internet Explorer 9+.
 
 Rickshaw relies on the HTMLElement#classList API, which isn't natively supported in Internet Explorer 9.  Rickshaw adds support by including a shim which implements the classList API by extending the HTMLElement prototype.  You can disable this behavior if you like, by setting `RICKSHAW_NO_COMPAT` to a true value before including the library. 
-
-
-## Dependencies
-
-Rickshaw relies on the fantastic [D3 visualization library](http://mbostock.github.com/d3/) to do lots of the heavy lifting for stacking and rendering to SVG.
-
-Some extensions require [jQuery](http://jquery.com) and [jQuery UI](http://jqueryui.com), but for drawing some basic graphs you'll be okay without.
-
-Rickshaw uses [jsdom](https://github.com/tmpvar/jsdom) to run unit tests in Node to be able to do SVG manipulation. As of the jsdom 7.0.0 release, jsdom requires Node.js 4 or newer [jsdom changelog](https://github.com/tmpvar/jsdom/blob/master/Changelog.md#700). If you want to run the tests on your machine, and you don't have access to a version of node >= 4.0, you can `npm install jsdom@3`  so that you can run the tests using the [3.x branch of jsdom](https://github.com/tmpvar/jsdom/tree/3.x).
 
 ## Building
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "preversion:src": "sed \"s/version: '[^,]*'/version: '$npm_package_version'/\" src/js/Rickshaw.js  > output &&  mv output src/js/Rickshaw.js",
     "preversion:bower": "sed 's/\"version\": \"[^,]*\"/\"version\": \"'$npm_package_version'\"/' bower.json  > output &&  mv output bower.json",
-    "version": "npm run preversion:src && npm run preversion:bower && make clean && make && npm test && git add -A src bower.json rickshaw.js rickshaw.min.js"
+    "version": "npm run preversion:src && npm run preversion:bower && make clean && make && npm test && git add -A src bower.json rickshaw.js rickshaw.min.js",
+    "doctoc": "doctoc --title='## Table of Contents' --github README.md"
   }
 }


### PR DESCRIPTION
This pull request adds a Table of Contents using `doctoc`, adds an npm-script to easily run it, and adds an install section to the README that more accurately reflects how to use the package. I also moved dependencies up to the Install section, as this is probably where it belongs.