### PR TITLE
Edit CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,14 @@
-## Pull requests are always welcome! 
+# Contribute to Rickshaw
+
+Thanks for contributing!
+
+## Issues
+
+We're currently overhauling how we do issues. Before we have a template in place and relevant labels, it would be great if you made your issue concise, clear, and to the point. If you have labels that you would suggest we add, please add this line with suggested labels at the bottom of the issue:
+
+`Suggested labels: example, another-example-label`
+
+## Pull requests are always welcome!
 
 Please follow a few guidelines:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,8 @@ We're currently overhauling how we do issues. Before we have a template in place
 
 `Suggested labels: example, another-example-label`
 
+If you'd like to weigh in on labels, check out [this issue](https://github.com/shutterstock/rickshaw/issues/588).
+
 ## Pull requests are always welcome!
 
 Please follow a few guidelines:


### PR DESCRIPTION
Right now, the Contributing file has nothing about READMEs. While #588 has been opened to talk about labels, I thought it would be good to have something in the CONTRIBUTING file about labels and issues, in general. This adds that, and should not be too controversial. In particular, I want to field possible labels from those submitting issues. This should cut down on internal time making labels that do not make sense.