### PR TITLE
fix: check undefined for series opacity

### DIFF
--- a/src/js/Rickshaw.Graph.Renderer.ScatterPlot.js
+++ b/src/js/Rickshaw.Graph.Renderer.ScatterPlot.js
@@ -35,7 +35,7 @@ Rickshaw.Graph.Renderer.ScatterPlot = Rickshaw.Class.create( Rickshaw.Graph.Rend
 		series.forEach( function(series) {
 
 			if (series.disabled) return;
-			var opacity = series.opacity ? series.opacity : 1;
+			var opacity = series.opacity === undefined ? 1 : series.opacity;
 
 			var nodes = vis.selectAll("path")
 				.data(series.stack.filter( function(d) { return d.y !== null } ))
@@ -47,7 +47,7 @@ Rickshaw.Graph.Renderer.ScatterPlot = Rickshaw.Class.create( Rickshaw.Graph.Rend
 			if (series.className) {
 				nodes.classed(series.className, true);
 			}
-			
+
 			Array.prototype.forEach.call(nodes[0], function(n) {
 				n.setAttribute('fill', series.color);
 			} );

--- a/src/js/Rickshaw.Graph.Renderer.js
+++ b/src/js/Rickshaw.Graph.Renderer.js
@@ -120,7 +120,7 @@ Rickshaw.Graph.Renderer = Rickshaw.Class.create( {
 		var fill = this.fill ? series.color : 'none';
 		var stroke = this.stroke ? series.color : 'none';
 		var strokeWidth = series.strokeWidth ? series.strokeWidth : this.strokeWidth;
-		var opacity = series.opacity ? series.opacity : this.opacity;
+		var opacity = series.opacity === undefined ? this.opacity : series.opacity;
 
 		series.path.setAttribute('fill', fill);
 		series.path.setAttribute('stroke', stroke);
@@ -179,4 +179,3 @@ Rickshaw.Graph.Renderer = Rickshaw.Class.create( {
 		}
 	}
 } );
-

--- a/tests/Rickshaw.Graph.Renderer.Scatterplot.js
+++ b/tests/Rickshaw.Graph.Renderer.Scatterplot.js
@@ -18,17 +18,55 @@ exports["should add the series className to all scatterplot points"] = function(
 					{ x: 3, y: 30 }
 				],
 				opacity: 0.8
-			}, {
+			},
+			{
 				className: 'fnord',
 				data  : [ { x: 4, y: 32 } ]
 			}
 		]
 	});
 	graph.render()
-	
+
 	var path = graph.vis.selectAll('circle.fnord')
 	test.equals(5, path.size())
+	test.done()
+}
+
+exports['should set series opacity correctly'] = function(test) {
+	var el = document.createElement("div");
+	var graph = new Rickshaw.Graph({
+		element: el,
+		stroke: true,
+		width: 10,
+		height: 10,
+		renderer: 'scatterplot',
+		series: [
+			{
+				className: 'fnord',
+				data: [
+					{ x: 0, y: 40 },
+					{ x: 1, y: 49 },
+					{ x: 2, y: 38 },
+					{ x: 3, y: 30 }
+				],
+				opacity: 0.8
+			},
+			{
+				className: 'fnord',
+				data  : [ { x: 4, y: 32 } ]
+			},
+			{
+				className: 'fnord',
+				opacity: 0,
+				data  : [ { x: 5, y: 32 } ]
+			}
+		]
+	});
+	graph.render()
+
+	var path = graph.vis.selectAll('circle.fnord')
 	test.equals(path[0][1].getAttribute('opacity'), 0.8, 'custom opacity')
-	test.equals(path[0][4].getAttribute('opacity'), 1, 'default opacity')
+	test.equals(path[0][4].getAttribute('opacity'), 1, 'default opacity should be 1')
+	test.equals(path[0][5].getAttribute('opacity'), 0, '0 opacity should be 0')
 	test.done()
 }


### PR DESCRIPTION
If we expect opacity to be a number, when `series.opacity = 0`, these ternaries would be falsey and set `series.opacity` to 1 by default. Check to see if opacity property is defined or not instead. 