### PR TITLE
docs: Fix simple typo, invterval -> interval

### DIFF
--- a/rickshaw.js
+++ b/rickshaw.js
@@ -3570,7 +3570,7 @@ Rickshaw.Graph.Renderer.Bar = Rickshaw.Class.create( Rickshaw.Graph.Renderer, {
 		
 		// Sorting object's keys returned to guarantee consistency when iterating over
 		// Keys order in `for .. in` loop is not specified and browsers behave differently here
-		// This results with different invterval value being calculated for different browsers
+		// This results with different interval value being calculated for different browsers
 		// See last but one section here: http://www.ecma-international.org/ecma-262/5.1/#sec-12.6.4
 		var keysSorted = Rickshaw.keys(intervalCounts).sort(function asc(a, b) { return Number(a) - Number(b); });
 		keysSorted.forEach( function(i) {

--- a/rickshaw.js
+++ b/rickshaw.js
@@ -3570,7 +3570,7 @@ Rickshaw.Graph.Renderer.Bar = Rickshaw.Class.create( Rickshaw.Graph.Renderer, {
 		
 		// Sorting object's keys returned to guarantee consistency when iterating over
 		// Keys order in `for .. in` loop is not specified and browsers behave differently here
-		// This results with different interval value being calculated for different browsers
+		// This results with different invterval value being calculated for different browsers
 		// See last but one section here: http://www.ecma-international.org/ecma-262/5.1/#sec-12.6.4
 		var keysSorted = Rickshaw.keys(intervalCounts).sort(function asc(a, b) { return Number(a) - Number(b); });
 		keysSorted.forEach( function(i) {

--- a/src/js/Rickshaw.Graph.Renderer.Bar.js
+++ b/src/js/Rickshaw.Graph.Renderer.Bar.js
@@ -101,7 +101,7 @@ Rickshaw.Graph.Renderer.Bar = Rickshaw.Class.create( Rickshaw.Graph.Renderer, {
 		
 		// Sorting object's keys returned to guarantee consistency when iterating over
 		// Keys order in `for .. in` loop is not specified and browsers behave differently here
-		// This results with different invterval value being calculated for different browsers
+		// This results with different interval value being calculated for different browsers
 		// See last but one section here: http://www.ecma-international.org/ecma-262/5.1/#sec-12.6.4
 		var keysSorted = Rickshaw.keys(intervalCounts).sort(function asc(a, b) { return Number(a) - Number(b); });
 		keysSorted.forEach( function(i) {


### PR DESCRIPTION
There is a small typo in rickshaw.js, src/js/Rickshaw.Graph.Renderer.Bar.js.

Should read `interval` rather than `invterval`.

