### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ For building, we use [Node](http://nodejs.org) and [npm](http://npmjs.org). Runn
 
 After doing a build you can run the tests with the command: `npm test`
 
-For more availible options see the [package.json](package.json) scripts section.
+For more available options see the [package.json](package.json) scripts section.
 
 
 ## Contributing

--- a/rickshaw.js
+++ b/rickshaw.js
@@ -1819,7 +1819,7 @@ Rickshaw.Graph.Behavior.Series.Highlight = function(args) {
 	var transformFn = args.transform || function(isActive, series) {
 		var newProperties = {};
 		if (!isActive) {
-			// backwards compability
+			// backwards compatibility
 			newProperties.color = disabledColor(series.color);
 		}
 		return newProperties;
@@ -3570,7 +3570,7 @@ Rickshaw.Graph.Renderer.Bar = Rickshaw.Class.create( Rickshaw.Graph.Renderer, {
 		
 		// Sorting object's keys returned to guarantee consistency when iterating over
 		// Keys order in `for .. in` loop is not specified and browsers behave differently here
-		// This results with different invterval value being calculated for different browsers
+		// This results with different interval value being calculated for different browsers
 		// See last but one section here: http://www.ecma-international.org/ecma-262/5.1/#sec-12.6.4
 		var keysSorted = Rickshaw.keys(intervalCounts).sort(function asc(a, b) { return Number(a) - Number(b); });
 		keysSorted.forEach( function(i) {

--- a/src/js/Rickshaw.Graph.Behavior.Series.Highlight.js
+++ b/src/js/Rickshaw.Graph.Behavior.Series.Highlight.js
@@ -17,7 +17,7 @@ Rickshaw.Graph.Behavior.Series.Highlight = function(args) {
 	var transformFn = args.transform || function(isActive, series) {
 		var newProperties = {};
 		if (!isActive) {
-			// backwards compability
+			// backwards compatibility
 			newProperties.color = disabledColor(series.color);
 		}
 		return newProperties;

--- a/tests/Rickshaw.Graph.DragZoom.js
+++ b/tests/Rickshaw.Graph.DragZoom.js
@@ -163,7 +163,7 @@ exports.notDrag = function(test) {
 	rect = d3.select(element).selectAll('rect')[0][0];
 	test.equal(rect, null, 'after mouseup rect is gone');
 
-	// This is not reproduceable in the browser
+	// This is not reproducible in the browser
 	event = global.document.createEvent('MouseEvent');
 	event.initMouseEvent('mousedown', true, true, window, 1, 800, 600, 290, 260, false, false, false, false, 0, null);
 	drag.svg[0][0].dispatchEvent(event);

--- a/tests/Rickshaw.Graph.Renderer.js
+++ b/tests/Rickshaw.Graph.Renderer.js
@@ -163,7 +163,7 @@ exports.respectStrokeFactory = function(test) {
 	var stroke = graph.vis.select('path.stroke.fnord');
 	test.equals(stroke.size(), 1, "we have a fnord stroke");
 	
-	// should also be availeable via series
+	// should also be available via series
 	var firstSeries = graph.series[0];
 	test.ok(d3.select(firstSeries.path).classed('path'), "selectable path");
 	test.ok(d3.select(firstSeries.stroke).classed('stroke', "selectable stroke"));


### PR DESCRIPTION
There are small typos in:
- README.md
- rickshaw.js
- src/js/Rickshaw.Graph.Behavior.Series.Highlight.js
- tests/Rickshaw.Graph.DragZoom.js
- tests/Rickshaw.Graph.Renderer.js

Fixes:
- Should read `compatibility` rather than `compability`.
- Should read `reproducible` rather than `reproduceable`.
- Should read `interval` rather than `invterval`.
- Should read `available` rather than `availible`.
- Should read `available` rather than `availeable`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md